### PR TITLE
Add local-only main-thread GUI tests for popup_window, tray_bridge, app (Fixes #15)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ tempfile = "3"
 rstest = "0.18"
 wiremock = "0.6"
 
+[[test]]
+name = "gui_main_thread"
+harness = false
+
 [lints.rust]
 unsafe_code = "warn"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    // Register `ci` as a known cfg so check-cfg doesn't warn.
+    println!("cargo:rustc-check-cfg=cfg(ci)");
+
+    // Emit `cfg(ci)` when running inside a CI environment so that tests
+    // requiring a live display / window-server can auto-skip in CI while
+    // still contributing to local coverage runs.
+    if std::env::var("CI").is_ok() || std::env::var("GITHUB_ACTIONS").is_ok() {
+        println!("cargo:rustc-cfg=ci");
+    }
+}

--- a/src/ui_gpui/app.rs
+++ b/src/ui_gpui/app.rs
@@ -165,32 +165,21 @@ impl GpuiApp {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn test_gpui_app_creation() {
+    #[test]
+    fn gpui_app_creation_succeeds() {
         let event_bus = EventBus::new(100);
         let app = GpuiApp::new(Arc::new(event_bus));
-
         assert!(app.is_ok());
-
-        if let Ok(app) = app {
-            // Verify bridge is created
-            let bridge = app.gpui_bridge();
-            assert!(Arc::strong_count(&bridge) >= 2);
-        }
     }
 
-    #[tokio::test]
-    #[ignore = "Requires macOS main thread GUI context"]
-    async fn test_gpui_app_initialization() {
+    /// `initialize()` requires the macOS main thread (creates `PopupWindow` + `TrayBridge`).
+    /// Full main-thread integration tests live in `tests/gui_main_thread.rs`.
+    #[test]
+    fn gpui_app_initialize_fails_off_main_thread() {
         let event_bus = EventBus::new(100);
-        let mut app = GpuiApp::new(Arc::new(event_bus)).unwrap();
+        let mut app = GpuiApp::new(Arc::new(event_bus)).expect("GpuiApp::new");
 
-        let init_result = app.initialize();
-        assert!(init_result.is_ok());
-
-        assert!(!app.is_popup_visible());
-
-        let forward_result = app.start_event_forwarding();
-        assert!(forward_result.is_ok());
+        let result = app.initialize();
+        assert!(result.is_err(), "initialize should fail off main thread");
     }
 }

--- a/src/ui_gpui/popup_window.rs
+++ b/src/ui_gpui/popup_window.rs
@@ -191,18 +191,18 @@ impl PopupWindow {
 mod tests {
     use super::*;
 
+    /// Validate that `PopupWindow::new` fails gracefully when not on the main thread.
+    /// Full main-thread integration tests live in `tests/gui_main_thread.rs`.
     #[test]
-    #[ignore = "Requires macOS main thread GUI context"]
-    fn test_popup_window_creation() {
-        let (user_tx, _user_rx) = flume::unbounded();
-        let (_view_cmd_tx, view_cmd_rx) = flume::unbounded();
-        let gpui_bridge = Arc::new(GpuiBridge::new(user_tx, view_cmd_rx));
+    fn popup_window_rejects_worker_thread() {
+        let (user_tx, _) = flume::unbounded();
+        let (_, view_rx) = flume::unbounded();
+        let bridge = Arc::new(GpuiBridge::new(user_tx, view_rx));
 
-        let popup = PopupWindow::new(gpui_bridge);
-        assert!(popup.is_ok());
-
-        if let Ok(window) = popup {
-            assert!(!window.is_visible());
-        }
+        let result = PopupWindow::new(bridge);
+        assert!(
+            result.is_err(),
+            "PopupWindow::new should fail off main thread"
+        );
     }
 }

--- a/src/ui_gpui/tray_bridge.rs
+++ b/src/ui_gpui/tray_bridge.rs
@@ -140,14 +140,18 @@ impl TrayBridge {
 mod tests {
     use super::*;
 
+    /// Validate that `TrayBridge::new` fails gracefully when not on the main thread.
+    /// Full main-thread integration tests live in `tests/gui_main_thread.rs`.
     #[test]
-    #[ignore = "Requires macOS main thread GUI context"]
-    fn test_tray_bridge_creation() {
-        let (user_tx, _user_rx) = flume::unbounded();
-        let (_view_cmd_tx, view_cmd_rx) = flume::unbounded();
-        let gpui_bridge = Arc::new(GpuiBridge::new(user_tx, view_cmd_rx));
+    fn tray_bridge_rejects_worker_thread() {
+        let (user_tx, _) = flume::unbounded();
+        let (_, view_rx) = flume::unbounded();
+        let bridge = Arc::new(GpuiBridge::new(user_tx, view_rx));
 
-        let tray = TrayBridge::new(gpui_bridge);
-        assert!(tray.is_ok());
+        let result = TrayBridge::new(bridge);
+        assert!(
+            result.is_err(),
+            "TrayBridge::new should fail off main thread"
+        );
     }
 }

--- a/tests/gui_main_thread.rs
+++ b/tests/gui_main_thread.rs
@@ -1,0 +1,201 @@
+//! Main-thread GUI integration tests for `PopupWindow`, `TrayBridge`, and `GpuiApp`.
+//!
+//! A custom harness (`harness = false`) is used so that `fn main()` — which IS the
+//! macOS main thread — runs the test bodies directly. In CI the binary exits 0.
+#![allow(clippy::too_many_lines)]
+
+#[cfg(ci)]
+fn main() {
+    println!("gui_main_thread: skipped in CI (no window server)");
+}
+
+#[cfg(not(ci))]
+fn main() {
+    let mut passed = 0u32;
+    let mut failed = 0u32;
+
+    run_test(
+        "popup_window::creation_and_visibility",
+        &mut passed,
+        &mut failed,
+        test_popup_creation,
+    );
+    run_test(
+        "popup_window::esc_and_resign_key_hide",
+        &mut passed,
+        &mut failed,
+        test_popup_esc_resign,
+    );
+    run_test(
+        "popup_window::bridge_is_shared",
+        &mut passed,
+        &mut failed,
+        test_popup_bridge_shared,
+    );
+    run_test(
+        "tray_bridge::creation_and_visibility",
+        &mut passed,
+        &mut failed,
+        test_tray_creation,
+    );
+    run_test(
+        "tray_bridge::toggle_popup_flips",
+        &mut passed,
+        &mut failed,
+        test_tray_toggle,
+    );
+    run_test(
+        "tray_bridge::click_outside_hides",
+        &mut passed,
+        &mut failed,
+        test_tray_click_outside,
+    );
+    run_test(
+        "tray_bridge::set_popup_window",
+        &mut passed,
+        &mut failed,
+        test_tray_set_popup,
+    );
+    run_test(
+        "gpui_app::init_and_event_forwarding",
+        &mut passed,
+        &mut failed,
+        test_app_init,
+    );
+    run_test(
+        "gpui_app::toggle_shutdown",
+        &mut passed,
+        &mut failed,
+        test_app_toggle_shutdown,
+    );
+
+    println!("\ntest result: {passed} passed; {failed} failed");
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}
+
+#[cfg(not(ci))]
+fn run_test(name: &str, passed: &mut u32, failed: &mut u32, f: fn()) {
+    print!("test {name} ... ");
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).is_ok() {
+        println!("ok");
+        *passed += 1;
+    } else {
+        println!("FAILED");
+        *failed += 1;
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+#[cfg(not(ci))]
+fn make_bridge() -> std::sync::Arc<personal_agent::ui_gpui::bridge::GpuiBridge> {
+    let (user_tx, _) = flume::unbounded();
+    let (_, view_rx) = flume::unbounded();
+    std::sync::Arc::new(personal_agent::ui_gpui::bridge::GpuiBridge::new(
+        user_tx, view_rx,
+    ))
+}
+
+// ── PopupWindow tests ────────────────────────────────────────────
+
+#[cfg(not(ci))]
+fn test_popup_creation() {
+    use personal_agent::ui_gpui::popup_window::PopupWindow;
+    let mut popup = PopupWindow::new(make_bridge()).expect("PopupWindow::new");
+    assert!(!popup.is_visible(), "should start hidden");
+    popup.show();
+    assert!(popup.is_visible(), "show makes visible");
+    popup.hide();
+    assert!(!popup.is_visible(), "hide makes invisible");
+}
+
+#[cfg(not(ci))]
+fn test_popup_esc_resign() {
+    use personal_agent::ui_gpui::popup_window::PopupWindow;
+    let mut popup = PopupWindow::new(make_bridge()).expect("PopupWindow::new");
+    popup.show();
+    popup.handle_esc_key();
+    assert!(!popup.is_visible(), "esc hides");
+    popup.show();
+    popup.handle_resign_key();
+    assert!(!popup.is_visible(), "resign hides");
+}
+
+#[cfg(not(ci))]
+fn test_popup_bridge_shared() {
+    use personal_agent::ui_gpui::popup_window::PopupWindow;
+    use std::sync::Arc;
+    let bridge = make_bridge();
+    let popup = PopupWindow::new(Arc::clone(&bridge)).expect("PopupWindow::new");
+    assert!(Arc::ptr_eq(&popup.gpui_bridge(), &bridge));
+}
+
+// ── TrayBridge tests ─────────────────────────────────────────────
+
+#[cfg(not(ci))]
+fn test_tray_creation() {
+    use personal_agent::ui_gpui::tray_bridge::TrayBridge;
+    let tray = TrayBridge::new(make_bridge()).expect("TrayBridge::new");
+    assert!(!tray.is_popup_visible());
+}
+
+#[cfg(not(ci))]
+fn test_tray_toggle() {
+    use personal_agent::ui_gpui::tray_bridge::TrayBridge;
+    let tray = TrayBridge::new(make_bridge()).expect("TrayBridge::new");
+    assert!(!tray.is_popup_visible());
+    tray.toggle_popup();
+    assert!(tray.is_popup_visible());
+    tray.toggle_popup();
+    assert!(!tray.is_popup_visible());
+}
+
+#[cfg(not(ci))]
+fn test_tray_click_outside() {
+    use personal_agent::ui_gpui::tray_bridge::TrayBridge;
+    let tray = TrayBridge::new(make_bridge()).expect("TrayBridge::new");
+    tray.toggle_popup();
+    assert!(tray.is_popup_visible());
+    tray.handle_click_outside();
+    assert!(!tray.is_popup_visible());
+}
+
+#[cfg(not(ci))]
+fn test_tray_set_popup() {
+    use personal_agent::ui_gpui::popup_window::PopupWindow;
+    use personal_agent::ui_gpui::tray_bridge::TrayBridge;
+    use std::sync::Arc;
+    let bridge = make_bridge();
+    let tray = TrayBridge::new(Arc::clone(&bridge)).expect("TrayBridge::new");
+    let popup = PopupWindow::new(Arc::clone(&bridge)).expect("PopupWindow::new");
+    tray.set_popup_window(popup);
+    assert!(!tray.is_popup_visible());
+}
+
+// ── GpuiApp tests ────────────────────────────────────────────────
+
+#[cfg(not(ci))]
+fn test_app_init() {
+    use personal_agent::events::EventBus;
+    use personal_agent::ui_gpui::app::GpuiApp;
+    use std::sync::Arc;
+    let mut app = GpuiApp::new(Arc::new(EventBus::new(100))).expect("GpuiApp::new");
+    app.initialize().expect("initialize");
+    assert!(!app.is_popup_visible());
+    app.start_event_forwarding()
+        .expect("start_event_forwarding");
+}
+
+#[cfg(not(ci))]
+fn test_app_toggle_shutdown() {
+    use personal_agent::events::EventBus;
+    use personal_agent::ui_gpui::app::GpuiApp;
+    use std::sync::Arc;
+    let mut app = GpuiApp::new(Arc::new(EventBus::new(100))).expect("GpuiApp::new");
+    app.initialize().expect("initialize");
+    assert!(!app.is_popup_visible());
+    app.toggle_popup();
+    app.shutdown();
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -156,9 +156,7 @@ fn coverage_ignore_regex() -> String {
         "src/bin/",
         // Requires live LLM provider
         "src/llm/client_agent.rs",
-        // macOS AppKit / IPC plumbing (requires window server)
-        "src/ui_gpui/popup_window.rs",
-        "src/ui_gpui/tray_bridge.rs",
+        // macOS AppKit / IPC global singletons (no meaningful branch logic)
         "src/ui_gpui/navigation_channel.rs",
         "src/ui_gpui/selection_intent_channel.rs",
         // GPUI declarative render + IME impls (require live GPUI window context)


### PR DESCRIPTION
Adds 9 behavioral GUI tests that exercise macOS AppKit objects (PopupWindow, TrayBridge, GpuiApp) on the actual main thread via a custom test harness.

**Problem**: These modules require `MainThreadMarker::new()` which only succeeds on the macOS main thread. Standard `cargo test` runs on worker threads, so tests were permanently `#[ignore]`d and contributed zero coverage.

**Solution**: A `harness = false` integration test where `fn main()` IS the main thread. A `build.rs` emits `cfg(ci)` in GitHub Actions so the binary compiles to a no-op in CI (no window server).

**Changes**:
- `build.rs` - emits `cfg(ci)` when CI/GITHUB_ACTIONS env vars are set
- `tests/gui_main_thread.rs` - 9 main-thread tests covering creation, visibility, toggle, esc/resign hide, click-outside, bridge sharing, init, event forwarding, shutdown
- Inline unit tests replaced with error-path validation (rejects worker thread)
- Removed `popup_window.rs` and `tray_bridge.rs` from coverage ignore regex