### PR TITLE
Strengthen CI clippy complexity gates (Fixes #13)

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,5 @@
-cognitive-complexity-threshold = 50
+cognitive-complexity-threshold = 45
+too-many-lines-threshold = 100
+too-many-arguments-threshold = 6
+max-struct-bools = 3
 type-complexity-threshold = 250
-too-many-arguments-threshold = 7

--- a/.github/workflows/pr-quality-and-e2e.yml
+++ b/.github/workflows/pr-quality-and-e2e.yml
@@ -46,7 +46,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: |
+          cargo clippy --all-targets -- \
+            -D warnings \
+            -D clippy::cognitive_complexity \
+            -D clippy::too_many_lines \
+            -D clippy::too_many_arguments \
+            -D clippy::type_complexity \
+            -D clippy::struct_excessive_bools
 
       - name: Install complexity tooling (lizard)
         run: |


### PR DESCRIPTION
Implements issue #13 by explicitly enforcing key Clippy complexity-shape lints in CI while keeping existing lizard, file-length, and coverage gates unchanged.

## What changed
- Added explicit deny flags to the lint job:
  - -D clippy::cognitive_complexity
  - -D clippy::too_many_lines
  - -D clippy::too_many_arguments
  - -D clippy::type_complexity
  - -D clippy::struct_excessive_bools
- Updated .clippy.toml thresholds consumed by those lints:
  - cognitive-complexity-threshold = 45
  - too-many-lines-threshold = 100
  - too-many-arguments-threshold = 6
  - max-struct-bools = 3
  - type-complexity-threshold = 250

## Notes
- Existing gates (lizard, file-length, coverage, tests, fmt) remain intact.
- This makes threshold enforcement explicit in CI and visible in required checks, matching the intent of issue #13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality thresholds and CI/CD linting enforcement to maintain stricter code standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->