### PR TITLE
Reset chat to bottom on open/switch with generation-safe transcript loads (Fixes #8)

### DIFF
--- a/src/ui_gpui/views/chat_view/command.rs
+++ b/src/ui_gpui/views/chat_view/command.rs
@@ -63,11 +63,20 @@ impl ChatView {
         match cmd {
             ViewCommand::ConversationMessagesLoaded {
                 conversation_id,
+                selection_generation,
                 messages,
-                ..
             } => {
                 if self.state.active_conversation_id != Some(conversation_id) {
                     tracing::info!(%conversation_id, "ChatView: ignoring ConversationMessagesLoaded for inactive conversation");
+                    return;
+                }
+                if selection_generation != self.selection_generation {
+                    tracing::info!(
+                        %conversation_id,
+                        selection_generation,
+                        current_generation = self.selection_generation,
+                        "ChatView: ignoring stale ConversationMessagesLoaded generation"
+                    );
                     return;
                 }
                 let message_count = messages.len();
@@ -255,9 +264,13 @@ impl ChatView {
                 self.apply_conversation_list_refresh(previous_active);
                 cx.notify();
             }
-            ViewCommand::ConversationActivated { id, .. } => {
+            ViewCommand::ConversationActivated {
+                id,
+                selection_generation,
+            } => {
                 self.state.active_conversation_id = Some(id);
                 self.conversation_id = Some(id);
+                self.selection_generation = selection_generation;
                 self.state.streaming = StreamingState::Idle;
                 self.state.thinking_content = None;
                 self.state.conversation_dropdown_open = false;
@@ -286,6 +299,7 @@ impl ChatView {
             ViewCommand::ConversationCreated { id, .. } => {
                 self.state.active_conversation_id = Some(id);
                 self.conversation_id = Some(id);
+                self.selection_generation = 0;
                 self.state.messages.clear();
                 self.state.streaming = StreamingState::Idle;
                 self.state.thinking_content = None;

--- a/src/ui_gpui/views/chat_view/mod.rs
+++ b/src/ui_gpui/views/chat_view/mod.rs
@@ -37,6 +37,7 @@ pub struct ChatView {
     pub(super) focus_handle: FocusHandle,
     pub(super) bridge: Option<Arc<GpuiBridge>>,
     pub(super) conversation_id: Option<Uuid>,
+    pub(super) selection_generation: u64,
     pub(super) chat_scroll_handle: ScrollHandle,
 }
 
@@ -47,6 +48,7 @@ impl ChatView {
             focus_handle: cx.focus_handle(),
             bridge: None,
             conversation_id: None,
+            selection_generation: 0,
             chat_scroll_handle: ScrollHandle::new(),
         }
     }
@@ -192,10 +194,46 @@ impl ChatView {
             ..
         } = snapshot;
 
+        let previous_conversation_id = self.conversation_id;
+        let previous_selection_generation = self.selection_generation;
+
         self.state.conversations = conversations;
         self.state.active_conversation_id = selected_conversation_id;
         self.conversation_id = selected_conversation_id;
         self.state.conversation_title = selected_conversation_title;
+
+        let should_reset_autoscroll = match &load_state {
+            ConversationLoadState::Loading {
+                conversation_id,
+                generation,
+            }
+            | ConversationLoadState::Ready {
+                conversation_id,
+                generation,
+            }
+            | ConversationLoadState::Error {
+                conversation_id,
+                generation,
+                ..
+            } => {
+                let changed = previous_conversation_id != Some(*conversation_id)
+                    || previous_selection_generation != *generation;
+                self.selection_generation = *generation;
+                changed
+            }
+            ConversationLoadState::Idle => {
+                let changed =
+                    previous_conversation_id.is_some() || previous_selection_generation != 0;
+                self.selection_generation = 0;
+                changed
+            }
+        };
+
+        if should_reset_autoscroll {
+            self.state.chat_autoscroll_enabled = true;
+            self.chat_scroll_handle.scroll_to_bottom();
+            self.maybe_scroll_chat_to_bottom(cx);
+        }
 
         match &load_state {
             ConversationLoadState::Ready { .. } => {
@@ -240,6 +278,7 @@ impl ChatView {
     /// @plan PLAN-20250130-GPUIREDUX.P04
     pub fn set_conversation_id(&mut self, id: Uuid) {
         self.conversation_id = Some(id);
+        self.selection_generation = 0;
         self.state.active_conversation_id = Some(id);
         self.state.sync_conversation_dropdown_index();
         self.state.sync_conversation_title_from_active();

--- a/tests/chat_view_handle_command_tests.rs
+++ b/tests/chat_view_handle_command_tests.rs
@@ -433,6 +433,13 @@ async fn handle_command_ignores_inactive_updates_and_replaces_active_transcript(
         view.state.streaming = StreamingState::Error("old error".to_string());
         view.state.conversations = vec![conversation(active_id, "Active", 1)];
         view.set_conversation_id(active_id);
+        view.handle_command(
+            ViewCommand::ConversationActivated {
+                id: active_id,
+                selection_generation: 2,
+            },
+            cx,
+        );
 
         view.handle_command(
             ViewCommand::ConversationMessagesLoaded {
@@ -497,6 +504,60 @@ async fn handle_command_ignores_inactive_updates_and_replaces_active_transcript(
         assert_eq!(view.state.streaming, StreamingState::Idle);
         assert_eq!(view.state.thinking_content, None);
         assert!(view.state.chat_autoscroll_enabled);
+    });
+}
+
+#[gpui::test]
+async fn stale_conversation_messages_loaded_generation_is_ignored(cx: &mut TestAppContext) {
+    let active_id = Uuid::new_v4();
+    let view = cx.new(|cx| ChatView::new(ChatState::default(), cx));
+
+    view.update(cx, |view: &mut ChatView, cx| {
+        view.state.current_model = "claude-3-7-sonnet".to_string();
+        view.state.conversations = vec![conversation(active_id, "Active", 1)];
+        view.handle_command(
+            ViewCommand::ConversationActivated {
+                id: active_id,
+                selection_generation: 2,
+            },
+            cx,
+        );
+
+        view.handle_command(
+            ViewCommand::ConversationMessagesLoaded {
+                conversation_id: active_id,
+                selection_generation: 1,
+                messages: vec![
+                    payload(ViewMessageRole::User, "stale user", None, Some(1)),
+                    payload(ViewMessageRole::Assistant, "stale assistant", None, Some(2)),
+                ],
+            },
+            cx,
+        );
+
+        view.handle_command(
+            ViewCommand::ConversationMessagesLoaded {
+                conversation_id: active_id,
+                selection_generation: 2,
+                messages: vec![
+                    payload(ViewMessageRole::User, "fresh user", None, Some(10)),
+                    payload(
+                        ViewMessageRole::Assistant,
+                        "fresh assistant",
+                        None,
+                        Some(20),
+                    ),
+                ],
+            },
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    view.read_with(cx, |view, _| {
+        assert_eq!(view.state.messages.len(), 2);
+        assert_eq!(view.state.messages[0].content, "fresh user");
+        assert_eq!(view.state.messages[1].content, "fresh assistant");
     });
 }
 


### PR DESCRIPTION
## Summary
- reset chat autoscroll to bottom whenever store selection changes by conversation or generation, including startup/open and conversation switch paths
- track selection generation in ChatView and reject stale ConversationMessagesLoaded payloads that no longer match the active generation
- add regression coverage for stale generation transcript payloads and align existing command-handling tests with generation-aware activation

## Verification
- cargo test --test chat_view_handle_command_tests stale_conversation_messages_loaded_generation_is_ignored
- cargo test --test chat_view_handle_command_tests
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --tests
- python3 -m lizard src/ui_gpui/views/chat_view/mod.rs src/ui_gpui/views/chat_view/command.rs tests/chat_view_handle_command_tests.rs
- cargo coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where outdated messages could appear when switching between conversations, ensuring only current conversation messages are displayed.

* **Tests**
  * Added comprehensive tests to verify message integrity and prevent stale message loading when navigating between conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->