### PR TITLE
Add tool approval settings UI with end-to-end wiring (Fixes #34)

### DIFF
--- a/project-plans/issue34.md
+++ b/project-plans/issue34.md
@@ -1,0 +1,54 @@
+# Issue #34: Tool Approval Settings UI — Implementation Plan
+
+## Status: IN PROGRESS
+
+823 lines added across 9 files. Plumbing is ~70% complete. Does NOT compile (1 error + 4 warnings).
+
+## What's Done (solid quality, follows project conventions)
+
+1. **Domain** (`tool_approval_policy.rs`): `deny_persistently()`, `remove_persistent_allow_prefix()`, `remove_persistent_deny_prefix()` + 3 async tests. [OK]
+2. **Events** (`events/types.rs`): 8 new `UserEvent` variants for all tool-approval actions. [OK]
+3. **ViewCommands** (`view_command.rs`): `ToolApprovalPolicyUpdated`, `RefreshToolApprovalSettings`. [OK]
+4. **Presenter** (`settings_presenter.rs`): Full load-save-emit cycle for 7 handlers + startup snapshot. [OK]
+5. **SettingsView state/logic** (`settings_view/mod.rs`): `ActiveField` enum, 10 state fields, field helpers, `EntityInputHandler`, key handling. [OK]
+6. **Chat YOLO wiring** (`render_bars.rs`): Emits `SetToolApprovalYoloMode` instead of local toggle. [OK]
+7. **MainPanel startup** (`startup.rs`): Emits `RefreshToolApprovalPolicy`. [OK]
+
+## Remaining Work
+
+### A. Fix compile error (settings_view/command.rs line 85)
+- `YoloModeChanged { enabled }` → `YoloModeChanged { active }` (field name mismatch)
+
+### B. Fix unused imports
+- `settings_view/mod.rs`: Remove `AppContext`
+- `settings_view/render.rs`: Imports will be consumed by step C
+
+### C. Render tool-approval UI section (settings_view/render.rs)
+The main visible feature — currently 0% done (only imports added):
+- `render_tool_approval_section()` containing:
+  - YOLO mode toggle (checkbox + warning text)
+  - Auto-approve read-only tools toggle (checkbox)
+  - MCP approval mode selector (Per Tool / Per Server radio-style)
+  - Allowlist: scrollable list with [x] remove, text input + [Add] button
+  - Denylist: same pattern as allowlist
+  - Status message bar (error/success)
+- IME canvas registration in main `render()` method
+- Add `.child(self.render_tool_approval_section(cx))` to main render
+
+### D. MainPanel command routing (command.rs + routing.rs)
+- `command.rs`: Route `ToolApprovalPolicyUpdated` → settings_view, `YoloModeChanged` → settings_view + chat_view
+- `routing.rs`: Add `tool_approval_policy_count` and `yolo_mode_changed_count` counters + match arms
+
+### E. Tests
+- Fix `start_runtime_requires_popup_window_before_emitting_refreshes` (expects only 2 `RefreshApiKeys`, now there's also `RefreshToolApprovalPolicy`)
+- Add routing test for `ToolApprovalPolicyUpdated` counter
+- Add routing test for `YoloModeChanged` counter
+- Add `#[gpui::test]` for `handle_command` forwarding `ToolApprovalPolicyUpdated` to settings_view
+
+### F. Verification
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --lib --tests`
+
+### G. Commit, push, open PR with `Fixes #34`
+### H. Watch CI + CodeRabbit, remediate until green

--- a/src/agent/tool_approval_policy.rs
+++ b/src/agent/tool_approval_policy.rs
@@ -173,6 +173,72 @@ impl ToolApprovalPolicy {
         self.save_to_settings(app_settings).await
     }
 
+    /// Add identifier to persistent denylist and save to settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persisting updated policy fails.
+    pub async fn deny_persistently(
+        &mut self,
+        identifier: impl Into<String>,
+        app_settings: &dyn AppSettingsService,
+    ) -> ServiceResult<()> {
+        let identifier = identifier.into();
+        if identifier.is_empty() || self.persistent_denylist.contains(&identifier) {
+            return Ok(());
+        }
+
+        self.persistent_denylist.push(identifier);
+        self.save_to_settings(app_settings).await
+    }
+
+    /// Remove identifier from persistent allowlist and save to settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persisting updated policy fails.
+    pub async fn remove_persistent_allow_prefix(
+        &mut self,
+        identifier: &str,
+        app_settings: &dyn AppSettingsService,
+    ) -> ServiceResult<()> {
+        if identifier.is_empty() {
+            return Ok(());
+        }
+
+        let original_len = self.persistent_allowlist.len();
+        self.persistent_allowlist
+            .retain(|entry| entry != identifier);
+        if self.persistent_allowlist.len() == original_len {
+            return Ok(());
+        }
+
+        self.save_to_settings(app_settings).await
+    }
+
+    /// Remove identifier from persistent denylist and save to settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persisting updated policy fails.
+    pub async fn remove_persistent_deny_prefix(
+        &mut self,
+        identifier: &str,
+        app_settings: &dyn AppSettingsService,
+    ) -> ServiceResult<()> {
+        if identifier.is_empty() {
+            return Ok(());
+        }
+
+        let original_len = self.persistent_denylist.len();
+        self.persistent_denylist.retain(|entry| entry != identifier);
+        if self.persistent_denylist.len() == original_len {
+            return Ok(());
+        }
+
+        self.save_to_settings(app_settings).await
+    }
+
     /// Add identifier to session-scoped allowlist (in-memory only).
     pub fn allow_for_session(&mut self, identifier: impl Into<String>) {
         let identifier = identifier.into();
@@ -680,6 +746,65 @@ mod tests {
             policy.persistent_allowlist,
             vec!["examcp/web_search".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn deny_persistently_updates_denylist_and_saves() {
+        let (service, _temp_dir) = create_settings_service();
+        let mut policy = ToolApprovalPolicy::default();
+
+        policy
+            .deny_persistently("rm", &service)
+            .await
+            .expect("deny persistently should succeed");
+
+        let loaded = ToolApprovalPolicy::load_from_settings(&service)
+            .await
+            .expect("load should succeed");
+
+        assert_eq!(loaded.persistent_denylist, vec!["rm".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn remove_persistent_allow_prefix_updates_allowlist_and_saves() {
+        let (service, _temp_dir) = create_settings_service();
+        let mut policy = ToolApprovalPolicy::default();
+        policy
+            .allow_persistently("examcp/web_search", &service)
+            .await
+            .expect("initial allow should persist");
+
+        policy
+            .remove_persistent_allow_prefix("examcp/web_search", &service)
+            .await
+            .expect("remove allow should succeed");
+
+        let loaded = ToolApprovalPolicy::load_from_settings(&service)
+            .await
+            .expect("load should succeed");
+
+        assert!(loaded.persistent_allowlist.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remove_persistent_deny_prefix_updates_denylist_and_saves() {
+        let (service, _temp_dir) = create_settings_service();
+        let mut policy = ToolApprovalPolicy::default();
+        policy
+            .deny_persistently("rm", &service)
+            .await
+            .expect("initial deny should persist");
+
+        policy
+            .remove_persistent_deny_prefix("rm", &service)
+            .await
+            .expect("remove deny should succeed");
+
+        let loaded = ToolApprovalPolicy::load_from_settings(&service)
+            .await
+            .expect("load should succeed");
+
+        assert!(loaded.persistent_denylist.is_empty());
     }
 
     #[tokio::test]

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -192,11 +192,35 @@ pub enum UserEvent {
     SelectTheme { slug: String },
 
     // ===== Tool Approval Actions =====
+    /// User requested a fresh tool approval policy snapshot.
+    RefreshToolApprovalPolicy,
+
     /// User responded to a tool approval request.
     ToolApprovalResponse {
         request_id: String,
         decision: ToolApprovalResponseAction,
     },
+
+    /// User toggled YOLO mode for tool approvals.
+    SetToolApprovalYoloMode { enabled: bool },
+
+    /// User toggled automatic approval for read-only tools.
+    SetToolApprovalAutoApproveReads { enabled: bool },
+
+    /// User selected MCP approval granularity.
+    SetToolApprovalMcpApprovalMode { mode: crate::agent::McpApprovalMode },
+
+    /// User added an allowlist prefix for persistent tool approvals.
+    AddToolApprovalAllowlistPrefix { prefix: String },
+
+    /// User removed an allowlist prefix for persistent tool approvals.
+    RemoveToolApprovalAllowlistPrefix { prefix: String },
+
+    /// User added a denylist prefix for persistent tool approvals.
+    AddToolApprovalDenylistPrefix { prefix: String },
+
+    /// User removed a denylist prefix for persistent tool approvals.
+    RemoveToolApprovalDenylistPrefix { prefix: String },
 
     // ===== Navigation =====
     /// User clicked to navigate to a view

--- a/src/presentation/mod.rs
+++ b/src/presentation/mod.rs
@@ -49,6 +49,7 @@ pub mod mcp_configure_presenter;
 pub mod model_selector_presenter;
 pub mod profile_editor_presenter;
 pub mod settings_presenter;
+mod settings_presenter_tool_approval;
 pub mod view_command;
 
 /// Presenter error type

--- a/src/presentation/settings_presenter.rs
+++ b/src/presentation/settings_presenter.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 use super::view_command::{ProfileSummary, ThemeSummary};
 use super::{Presenter, PresenterError, ViewCommand};
+
 use crate::events::{
     emit,
     types::{McpEvent, ProfileEvent, SystemEvent, UserEvent},
@@ -117,6 +118,7 @@ impl SettingsPresenter {
         .await;
 
         Self::emit_theme_snapshot(&self.app_settings_service, &self.view_tx, None).await;
+        Self::emit_tool_approval_policy_snapshot(&self.app_settings_service, &self.view_tx).await;
 
         let mut rx = self.rx.resubscribe();
         let running = self.running.clone();
@@ -231,6 +233,48 @@ impl SettingsPresenter {
             UserEvent::RefreshProfiles => {
                 Self::emit_profiles_snapshot(profile_service, app_settings_service, view_tx).await;
                 Self::emit_theme_snapshot(app_settings_service, view_tx, None).await;
+                Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+            }
+            UserEvent::RefreshToolApprovalPolicy => {
+                Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+            }
+            UserEvent::SetToolApprovalYoloMode { enabled } => {
+                Self::on_set_tool_approval_yolo_mode(app_settings_service, view_tx, enabled).await;
+            }
+            UserEvent::SetToolApprovalAutoApproveReads { enabled } => {
+                Self::on_set_tool_approval_auto_approve_reads(
+                    app_settings_service,
+                    view_tx,
+                    enabled,
+                )
+                .await;
+            }
+            UserEvent::SetToolApprovalMcpApprovalMode { mode } => {
+                Self::on_set_tool_approval_mcp_mode(app_settings_service, view_tx, mode).await;
+            }
+            UserEvent::AddToolApprovalAllowlistPrefix { prefix } => {
+                Self::on_add_tool_approval_allowlist_prefix(app_settings_service, view_tx, prefix)
+                    .await;
+            }
+            UserEvent::RemoveToolApprovalAllowlistPrefix { prefix } => {
+                Self::on_remove_tool_approval_allowlist_prefix(
+                    app_settings_service,
+                    view_tx,
+                    prefix,
+                )
+                .await;
+            }
+            UserEvent::AddToolApprovalDenylistPrefix { prefix } => {
+                Self::on_add_tool_approval_denylist_prefix(app_settings_service, view_tx, prefix)
+                    .await;
+            }
+            UserEvent::RemoveToolApprovalDenylistPrefix { prefix } => {
+                Self::on_remove_tool_approval_denylist_prefix(
+                    app_settings_service,
+                    view_tx,
+                    prefix,
+                )
+                .await;
             }
             UserEvent::ToggleMcp { id, enabled } => {
                 Self::on_toggle_mcp(view_tx, id, enabled);

--- a/src/presentation/settings_presenter_tool_approval.rs
+++ b/src/presentation/settings_presenter_tool_approval.rs
@@ -1,0 +1,297 @@
+//! Tool approval policy handlers for `SettingsPresenter`.
+
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use super::settings_presenter::SettingsPresenter;
+use super::view_command::ViewCommand;
+use crate::agent::tool_approval_policy::{McpApprovalMode, ToolApprovalPolicy};
+use crate::services::app_settings::AppSettingsService;
+
+impl SettingsPresenter {
+    pub(super) async fn emit_tool_approval_policy_snapshot(
+        app_settings_service: &Arc<dyn AppSettingsService>,
+        view_tx: &broadcast::Sender<ViewCommand>,
+    ) {
+        match ToolApprovalPolicy::load_from_settings(app_settings_service.as_ref()).await {
+            Ok(policy) => {
+                let _ = view_tx.send(ViewCommand::ToolApprovalPolicyUpdated {
+                    yolo_mode: policy.yolo_mode,
+                    auto_approve_reads: policy.auto_approve_reads,
+                    mcp_approval_mode: policy.mcp_approval_mode,
+                    persistent_allowlist: policy.persistent_allowlist,
+                    persistent_denylist: policy.persistent_denylist,
+                });
+                let _ = view_tx.send(ViewCommand::YoloModeChanged {
+                    active: policy.yolo_mode,
+                });
+            }
+            Err(error) => {
+                tracing::warn!("Failed to load tool approval policy snapshot: {error}");
+                let _ = view_tx.send(ViewCommand::ShowError {
+                    title: "Tool Approval Settings".to_string(),
+                    message: "Failed to load tool approval settings".to_string(),
+                    severity: super::view_command::ErrorSeverity::Warning,
+                });
+            }
+        }
+    }
+
+    pub(super) async fn on_set_tool_approval_yolo_mode(
+        app_settings_service: &Arc<dyn AppSettingsService>,
+        view_tx: &broadcast::Sender<ViewCommand>,
+        enabled: bool,
+    ) {
+        let mut policy =
+            match ToolApprovalPolicy::load_from_settings(app_settings_service.as_ref()).await {
+                Ok(policy) => policy,
+                Err(error) => {
+                    tracing::warn!("Failed to load tool approval policy for YOLO toggle: {error}");
+                    let _ = view_tx.send(ViewCommand::ShowError {
+                        title: "Tool Approval Settings".to_string(),
+                        message: "Failed to update YOLO mode".to_string(),
+                        severity: super::view_command::ErrorSeverity::Warning,
+                    });
+                    return;
+                }
+            };
+
+        if policy.yolo_mode == enabled {
+            let _ = view_tx.send(ViewCommand::YoloModeChanged { active: enabled });
+            return;
+        }
+
+        policy.yolo_mode = enabled;
+        if let Err(error) = policy.save_to_settings(app_settings_service.as_ref()).await {
+            tracing::warn!("Failed to persist YOLO mode: {error}");
+            let _ = view_tx.send(ViewCommand::ShowError {
+                title: "Tool Approval Settings".to_string(),
+                message: "Failed to persist YOLO mode".to_string(),
+                severity: super::view_command::ErrorSeverity::Warning,
+            });
+            return;
+        }
+
+        Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+    }
+
+    pub(super) async fn on_set_tool_approval_auto_approve_reads(
+        app_settings_service: &Arc<dyn AppSettingsService>,
+        view_tx: &broadcast::Sender<ViewCommand>,
+        enabled: bool,
+    ) {
+        let mut policy =
+            match ToolApprovalPolicy::load_from_settings(app_settings_service.as_ref()).await {
+                Ok(policy) => policy,
+                Err(error) => {
+                    tracing::warn!("Failed to load tool approval policy for read toggle: {error}");
+                    let _ = view_tx.send(ViewCommand::ShowError {
+                        title: "Tool Approval Settings".to_string(),
+                        message: "Failed to update read-only approval mode".to_string(),
+                        severity: super::view_command::ErrorSeverity::Warning,
+                    });
+                    return;
+                }
+            };
+
+        if policy.auto_approve_reads == enabled {
+            return;
+        }
+
+        policy.auto_approve_reads = enabled;
+        if let Err(error) = policy.save_to_settings(app_settings_service.as_ref()).await {
+            tracing::warn!("Failed to persist read-only approval mode: {error}");
+            let _ = view_tx.send(ViewCommand::ShowError {
+                title: "Tool Approval Settings".to_string(),
+                message: "Failed to persist read-only approval mode".to_string(),
+                severity: super::view_command::ErrorSeverity::Warning,
+            });
+            return;
+        }
+
+        Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+    }
+
+    pub(super) async fn on_set_tool_approval_mcp_mode(
+        app_settings_service: &Arc<dyn AppSettingsService>,
+        view_tx: &broadcast::Sender<ViewCommand>,
+        mode: McpApprovalMode,
+    ) {
+        let mut policy = match ToolApprovalPolicy::load_from_settings(app_settings_service.as_ref())
+            .await
+        {
+            Ok(policy) => policy,
+            Err(error) => {
+                tracing::warn!("Failed to load tool approval policy for MCP mode change: {error}");
+                let _ = view_tx.send(ViewCommand::ShowError {
+                    title: "Tool Approval Settings".to_string(),
+                    message: "Failed to update MCP approval mode".to_string(),
+                    severity: super::view_command::ErrorSeverity::Warning,
+                });
+                return;
+            }
+        };
+
+        if policy.mcp_approval_mode == mode {
+            return;
+        }
+
+        policy.mcp_approval_mode = mode;
+        if let Err(error) = policy.save_to_settings(app_settings_service.as_ref()).await {
+            tracing::warn!("Failed to persist MCP approval mode: {error}");
+            let _ = view_tx.send(ViewCommand::ShowError {
+                title: "Tool Approval Settings".to_string(),
+                message: "Failed to persist MCP approval mode".to_string(),
+                severity: super::view_command::ErrorSeverity::Warning,
+            });
+            return;
+        }
+
+        Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+    }
+
+    pub(super) async fn on_add_tool_approval_allowlist_prefix(
+        app_settings_service: &Arc<dyn AppSettingsService>,
+        view_tx: &broadcast::Sender<ViewCommand>,
+        prefix: String,
+    ) {
+        let mut policy = match ToolApprovalPolicy::load_from_settings(app_settings_service.as_ref())
+            .await
+        {
+            Ok(policy) => policy,
+            Err(error) => {
+                tracing::warn!("Failed to load tool approval policy for allowlist add: {error}");
+                let _ = view_tx.send(ViewCommand::ShowError {
+                    title: "Tool Approval Settings".to_string(),
+                    message: "Failed to update allowlist".to_string(),
+                    severity: super::view_command::ErrorSeverity::Warning,
+                });
+                return;
+            }
+        };
+
+        if let Err(error) = policy
+            .allow_persistently(prefix.trim().to_string(), app_settings_service.as_ref())
+            .await
+        {
+            tracing::warn!("Failed to persist allowlist entry: {error}");
+            let _ = view_tx.send(ViewCommand::ShowError {
+                title: "Tool Approval Settings".to_string(),
+                message: "Failed to persist allowlist entry".to_string(),
+                severity: super::view_command::ErrorSeverity::Warning,
+            });
+            return;
+        }
+
+        Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+    }
+
+    pub(super) async fn on_remove_tool_approval_allowlist_prefix(
+        app_settings_service: &Arc<dyn AppSettingsService>,
+        view_tx: &broadcast::Sender<ViewCommand>,
+        prefix: String,
+    ) {
+        let mut policy =
+            match ToolApprovalPolicy::load_from_settings(app_settings_service.as_ref()).await {
+                Ok(policy) => policy,
+                Err(error) => {
+                    tracing::warn!(
+                        "Failed to load tool approval policy for allowlist removal: {error}"
+                    );
+                    let _ = view_tx.send(ViewCommand::ShowError {
+                        title: "Tool Approval Settings".to_string(),
+                        message: "Failed to update allowlist".to_string(),
+                        severity: super::view_command::ErrorSeverity::Warning,
+                    });
+                    return;
+                }
+            };
+
+        if let Err(error) = policy
+            .remove_persistent_allow_prefix(prefix.trim(), app_settings_service.as_ref())
+            .await
+        {
+            tracing::warn!("Failed to remove allowlist entry: {error}");
+            let _ = view_tx.send(ViewCommand::ShowError {
+                title: "Tool Approval Settings".to_string(),
+                message: "Failed to remove allowlist entry".to_string(),
+                severity: super::view_command::ErrorSeverity::Warning,
+            });
+            return;
+        }
+
+        Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+    }
+
+    pub(super) async fn on_add_tool_approval_denylist_prefix(
+        app_settings_service: &Arc<dyn AppSettingsService>,
+        view_tx: &broadcast::Sender<ViewCommand>,
+        prefix: String,
+    ) {
+        let mut policy =
+            match ToolApprovalPolicy::load_from_settings(app_settings_service.as_ref()).await {
+                Ok(policy) => policy,
+                Err(error) => {
+                    tracing::warn!("Failed to load tool approval policy for denylist add: {error}");
+                    let _ = view_tx.send(ViewCommand::ShowError {
+                        title: "Tool Approval Settings".to_string(),
+                        message: "Failed to update denylist".to_string(),
+                        severity: super::view_command::ErrorSeverity::Warning,
+                    });
+                    return;
+                }
+            };
+
+        if let Err(error) = policy
+            .deny_persistently(prefix.trim().to_string(), app_settings_service.as_ref())
+            .await
+        {
+            tracing::warn!("Failed to persist denylist entry: {error}");
+            let _ = view_tx.send(ViewCommand::ShowError {
+                title: "Tool Approval Settings".to_string(),
+                message: "Failed to persist denylist entry".to_string(),
+                severity: super::view_command::ErrorSeverity::Warning,
+            });
+            return;
+        }
+
+        Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+    }
+
+    pub(super) async fn on_remove_tool_approval_denylist_prefix(
+        app_settings_service: &Arc<dyn AppSettingsService>,
+        view_tx: &broadcast::Sender<ViewCommand>,
+        prefix: String,
+    ) {
+        let mut policy = match ToolApprovalPolicy::load_from_settings(app_settings_service.as_ref())
+            .await
+        {
+            Ok(policy) => policy,
+            Err(error) => {
+                tracing::warn!("Failed to load tool approval policy for denylist removal: {error}");
+                let _ = view_tx.send(ViewCommand::ShowError {
+                    title: "Tool Approval Settings".to_string(),
+                    message: "Failed to update denylist".to_string(),
+                    severity: super::view_command::ErrorSeverity::Warning,
+                });
+                return;
+            }
+        };
+
+        if let Err(error) = policy
+            .remove_persistent_deny_prefix(prefix.trim(), app_settings_service.as_ref())
+            .await
+        {
+            tracing::warn!("Failed to remove denylist entry: {error}");
+            let _ = view_tx.send(ViewCommand::ShowError {
+                title: "Tool Approval Settings".to_string(),
+                message: "Failed to remove denylist entry".to_string(),
+                severity: super::view_command::ErrorSeverity::Warning,
+            });
+            return;
+        }
+
+        Self::emit_tool_approval_policy_snapshot(app_settings_service, view_tx).await;
+    }
+}

--- a/src/presentation/view_command.rs
+++ b/src/presentation/view_command.rs
@@ -10,6 +10,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::agent::McpApprovalMode;
 use crate::models::ConversationExportFormat;
 
 /// Command from presenter to UI layer
@@ -266,6 +267,18 @@ pub enum ViewCommand {
 
     /// Inform the UI whether YOLO mode is currently active.
     YoloModeChanged { active: bool },
+
+    /// Update settings surfaces with the current persisted tool approval policy.
+    ToolApprovalPolicyUpdated {
+        yolo_mode: bool,
+        auto_approve_reads: bool,
+        mcp_approval_mode: McpApprovalMode,
+        persistent_allowlist: Vec<String>,
+        persistent_denylist: Vec<String>,
+    },
+
+    /// Request presenters/views to refresh tool approval settings from persistence.
+    RefreshToolApprovalSettings,
 
     // ===== Error Commands =====
     /// Show error to user

--- a/src/ui_gpui/views/chat_view/render_bars.rs
+++ b/src/ui_gpui/views/chat_view/render_bars.rs
@@ -105,7 +105,8 @@ impl ChatView {
                 "Y",
                 yolo_active,
                 cx.listener(|this, _, _window, cx| {
-                    this.state.yolo_mode = !this.state.yolo_mode;
+                    let next = !this.state.yolo_mode;
+                    this.emit(UserEvent::SetToolApprovalYoloMode { enabled: next });
                     cx.notify();
                 })
             ))

--- a/src/ui_gpui/views/main_panel/command.rs
+++ b/src/ui_gpui/views/main_panel/command.rs
@@ -62,6 +62,14 @@ impl MainPanel {
                 self.handle_model_profile_command(cmd, cx);
             }
 
+            // ── tool approval (settings + chat) ────────────────────────
+            ToolApprovalPolicyUpdated { .. } => {
+                self.forward_to_settings(cmd, cx);
+            }
+            YoloModeChanged { .. } => {
+                self.forward_yolo_to_settings_and_chat(&cmd, cx);
+            }
+
             // ── settings + profiles (non-store) ────────────────────────
             ShowSettingsTheme { .. }
             | ProfileCreated { .. }
@@ -97,6 +105,30 @@ impl MainPanel {
             chat.update(cx, |view, cx| {
                 view.handle_command(cmd, cx);
             });
+        }
+    }
+
+    fn forward_to_settings(&self, cmd: ViewCommand, cx: &mut gpui::Context<Self>) {
+        if let Some(ref settings) = self.settings_view {
+            settings.update(cx, |view, cx| {
+                view.handle_command(cmd, cx);
+            });
+        }
+    }
+
+    fn forward_yolo_to_settings_and_chat(&self, cmd: &ViewCommand, cx: &mut gpui::Context<Self>) {
+        if let ViewCommand::YoloModeChanged { active } = cmd {
+            let active = *active;
+            if let Some(ref settings) = self.settings_view {
+                settings.update(cx, |view, cx| {
+                    view.handle_command(ViewCommand::YoloModeChanged { active }, cx);
+                });
+            }
+            if let Some(ref chat) = self.chat_view {
+                chat.update(cx, |view, cx| {
+                    view.handle_command(ViewCommand::YoloModeChanged { active }, cx);
+                });
+            }
         }
     }
 

--- a/src/ui_gpui/views/main_panel/routing.rs
+++ b/src/ui_gpui/views/main_panel/routing.rs
@@ -65,6 +65,10 @@ pub struct CommandTargets {
 
     // Profile prefill state from model selector
     pub profile_prefill_selected_count: usize,
+
+    // Tool approval routing counters
+    pub tool_approval_policy_count: usize,
+    pub yolo_mode_changed_count: usize,
 }
 
 /// Route a single `ViewCommand` to the correct target view state.
@@ -132,6 +136,14 @@ pub fn route_view_command(cmd: ViewCommand, targets: &mut CommandTargets) {
         // ── Profile prefill ────────────────────────────────────────────────
         ViewCommand::ModelSelected { .. } | ViewCommand::ProfileEditorLoad { .. } => {
             targets.profile_prefill_selected_count += 1;
+        }
+
+        // ── Tool approval ────────────────────────────────────────────────
+        ViewCommand::ToolApprovalPolicyUpdated { .. } => {
+            targets.tool_approval_policy_count += 1;
+        }
+        ViewCommand::YoloModeChanged { .. } => {
+            targets.yolo_mode_changed_count += 1;
         }
 
         // All other commands are store-managed, navigation, or ancillary

--- a/src/ui_gpui/views/main_panel/startup.rs
+++ b/src/ui_gpui/views/main_panel/startup.rs
@@ -69,6 +69,7 @@ impl MainPanel {
             let _ = bridge.emit(UserEvent::RefreshProfiles);
             let _ = bridge.emit(UserEvent::RefreshHistory);
             let _ = bridge.emit(UserEvent::RefreshApiKeys);
+            let _ = bridge.emit(UserEvent::RefreshToolApprovalPolicy);
         }
     }
 

--- a/src/ui_gpui/views/main_panel/tests.rs
+++ b/src/ui_gpui/views/main_panel/tests.rs
@@ -310,17 +310,14 @@ async fn start_runtime_requires_popup_window_before_emitting_refreshes(cx: &mut 
         assert!(panel.test_conversation_switch_task.is_none());
     });
 
+    let mut pre_popup_events = Vec::new();
+    while let Ok(event) = user_rx.try_recv() {
+        pre_popup_events.push(event);
+    }
     assert_eq!(
-        user_rx.recv().expect("profile editor refresh"),
-        UserEvent::RefreshApiKeys
-    );
-    assert_eq!(
-        user_rx.recv().expect("api key manager refresh"),
-        UserEvent::RefreshApiKeys
-    );
-    assert!(
-        user_rx.try_recv().is_err(),
-        "runtime should not emit snapshot refreshes before popup window exists"
+        pre_popup_events,
+        vec![UserEvent::RefreshApiKeys, UserEvent::RefreshApiKeys],
+        "runtime should only emit RefreshApiKeys events (no snapshot refreshes) before popup window exists"
     );
 }
 
@@ -751,6 +748,96 @@ async fn handle_command_does_not_forward_non_export_feedback_to_chat_view(cx: &m
         chat_view.read_with(cx, |view, _| {
             assert_eq!(view.state.export_feedback_message, None);
             assert!(!view.state.export_feedback_is_error);
+        });
+    });
+}
+
+#[gpui::test]
+async fn route_tool_approval_policy_updated_increments_counter(cx: &mut TestAppContext) {
+    let _ = cx;
+    assert_route_count(
+        ViewCommand::ToolApprovalPolicyUpdated {
+            yolo_mode: true,
+            auto_approve_reads: false,
+            mcp_approval_mode: crate::agent::McpApprovalMode::PerTool,
+            persistent_allowlist: vec!["git".to_string()],
+            persistent_denylist: vec!["rm".to_string()],
+        },
+        1,
+        |targets| targets.tool_approval_policy_count,
+    );
+}
+
+#[gpui::test]
+async fn route_yolo_mode_changed_increments_counter(cx: &mut TestAppContext) {
+    let _ = cx;
+    assert_route_count(
+        ViewCommand::YoloModeChanged { active: true },
+        1,
+        |targets| targets.yolo_mode_changed_count,
+    );
+}
+
+#[gpui::test]
+async fn handle_command_forwards_tool_approval_policy_to_settings_view(cx: &mut TestAppContext) {
+    let (app_state, _user_rx, _first_id, _second_id, _selected_profile_id) = build_app_state();
+    cx.set_global(app_state);
+    let panel = cx.new(MainPanel::new);
+
+    panel.update(cx, |panel: &mut MainPanel, cx| {
+        panel.init(cx);
+
+        panel.handle_command(
+            ViewCommand::ToolApprovalPolicyUpdated {
+                yolo_mode: true,
+                auto_approve_reads: true,
+                mcp_approval_mode: crate::agent::McpApprovalMode::PerServer,
+                persistent_allowlist: vec!["git".to_string(), "ls".to_string()],
+                persistent_denylist: vec!["rm".to_string()],
+            },
+            cx,
+        );
+
+        let settings_view = panel
+            .settings_view
+            .as_ref()
+            .expect("settings view initialized");
+        settings_view.read_with(cx, |view, _| {
+            let state = view.get_state();
+            assert!(state.yolo_mode);
+            assert!(state.auto_approve_reads);
+            assert_eq!(
+                state.mcp_approval_mode,
+                crate::agent::McpApprovalMode::PerServer
+            );
+            assert_eq!(state.persistent_allowlist, vec!["git", "ls"]);
+            assert_eq!(state.persistent_denylist, vec!["rm"]);
+        });
+    });
+}
+
+#[gpui::test]
+async fn handle_command_forwards_yolo_mode_changed_to_settings_and_chat(cx: &mut TestAppContext) {
+    let (app_state, _user_rx, _first_id, _second_id, _selected_profile_id) = build_app_state();
+    cx.set_global(app_state);
+    let panel = cx.new(MainPanel::new);
+
+    panel.update(cx, |panel: &mut MainPanel, cx| {
+        panel.init(cx);
+
+        panel.handle_command(ViewCommand::YoloModeChanged { active: true }, cx);
+
+        let settings_view = panel
+            .settings_view
+            .as_ref()
+            .expect("settings view initialized");
+        settings_view.read_with(cx, |view, _| {
+            assert!(view.get_state().yolo_mode);
+        });
+
+        let chat_view = panel.chat_view.as_ref().expect("chat view initialized");
+        chat_view.read_with(cx, |view, _| {
+            assert!(view.state.yolo_mode);
         });
     });
 }

--- a/src/ui_gpui/views/settings_view/command.rs
+++ b/src/ui_gpui/views/settings_view/command.rs
@@ -69,6 +69,32 @@ impl SettingsView {
                     self.state.selected_mcp_id = self.state.mcps.first().map(|m| m.id);
                 }
             }
+            ViewCommand::ToolApprovalPolicyUpdated {
+                yolo_mode,
+                auto_approve_reads,
+                mcp_approval_mode,
+                persistent_allowlist,
+                persistent_denylist,
+            } => {
+                self.state.yolo_mode = yolo_mode;
+                self.state.auto_approve_reads = auto_approve_reads;
+                self.state.mcp_approval_mode = mcp_approval_mode;
+                self.state.persistent_allowlist = persistent_allowlist;
+                self.state.persistent_denylist = persistent_denylist;
+                self.state.allowlist_input.clear();
+                self.state.denylist_input.clear();
+            }
+            ViewCommand::YoloModeChanged { active } => {
+                self.state.yolo_mode = active;
+            }
+            ViewCommand::ShowNotification { message } => {
+                self.state.status_message = Some(message);
+                self.state.status_is_error = false;
+            }
+            ViewCommand::ShowError { title, message, .. } => {
+                self.state.status_message = Some(format!("{title}: {message}"));
+                self.state.status_is_error = true;
+            }
             _ => {}
         }
         cx.notify();

--- a/src/ui_gpui/views/settings_view/mod.rs
+++ b/src/ui_gpui/views/settings_view/mod.rs
@@ -5,11 +5,16 @@
 
 mod command;
 mod render;
+mod render_tool_approval;
 
-use gpui::FocusHandle;
+use gpui::{Bounds, Pixels};
+
+use gpui::{FocusHandle, Window};
+use std::ops::Range;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use crate::agent::McpApprovalMode;
 use crate::events::types::UserEvent;
 use crate::presentation::view_command::{ProfileSummary, ThemeSummary};
 use crate::ui_gpui::bridge::GpuiBridge;
@@ -119,6 +124,12 @@ pub struct ThemeOption {
     pub slug: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ActiveField {
+    AllowlistInput,
+    DenylistInput,
+}
+
 /// Settings view state
 /// @plan PLAN-20250130-GPUIREDUX.P06
 pub struct SettingsState {
@@ -130,6 +141,16 @@ pub struct SettingsState {
     pub available_themes: Vec<ThemeOption>,
     /// Slug of the currently-selected theme.
     pub selected_theme_slug: String,
+    pub yolo_mode: bool,
+    pub auto_approve_reads: bool,
+    pub mcp_approval_mode: McpApprovalMode,
+    pub persistent_allowlist: Vec<String>,
+    pub persistent_denylist: Vec<String>,
+    pub allowlist_input: String,
+    pub denylist_input: String,
+    pub(super) active_field: Option<ActiveField>,
+    pub status_message: Option<String>,
+    pub status_is_error: bool,
 }
 
 impl SettingsState {
@@ -148,6 +169,16 @@ impl Default for SettingsState {
             selected_mcp_id: None,
             available_themes: Vec::new(),
             selected_theme_slug: "green-screen".to_string(),
+            yolo_mode: false,
+            auto_approve_reads: false,
+            mcp_approval_mode: McpApprovalMode::PerTool,
+            persistent_allowlist: Vec::new(),
+            persistent_denylist: Vec::new(),
+            allowlist_input: String::new(),
+            denylist_input: String::new(),
+            active_field: None,
+            status_message: None,
+            status_is_error: false,
         }
     }
 }
@@ -158,6 +189,7 @@ pub struct SettingsView {
     pub(super) state: SettingsState,
     pub(super) bridge: Option<Arc<GpuiBridge>>,
     pub(super) focus_handle: FocusHandle,
+    pub(super) ime_marked_byte_count: usize,
 }
 
 impl SettingsView {
@@ -166,6 +198,7 @@ impl SettingsView {
             state: SettingsState::new(),
             bridge: None,
             focus_handle: cx.focus_handle(),
+            ime_marked_byte_count: 0,
         }
     }
 
@@ -286,6 +319,111 @@ impl SettingsView {
             .position(|theme| theme.slug == self.state.selected_theme_slug)
     }
 
+    fn append_to_active_field(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+
+        match self.state.active_field {
+            Some(ActiveField::AllowlistInput) => self.state.allowlist_input.push_str(text),
+            Some(ActiveField::DenylistInput) => self.state.denylist_input.push_str(text),
+            None => {}
+        }
+    }
+
+    fn backspace_active_field(&mut self) {
+        match self.state.active_field {
+            Some(ActiveField::AllowlistInput) => {
+                self.state.allowlist_input.pop();
+            }
+            Some(ActiveField::DenylistInput) => {
+                self.state.denylist_input.pop();
+            }
+            None => {}
+        }
+    }
+
+    fn remove_trailing_bytes_from_active_field(&mut self, byte_count: usize) {
+        if byte_count == 0 {
+            return;
+        }
+
+        match self.state.active_field {
+            Some(ActiveField::AllowlistInput) => {
+                let len = self.state.allowlist_input.len();
+                self.state
+                    .allowlist_input
+                    .truncate(len.saturating_sub(byte_count));
+            }
+            Some(ActiveField::DenylistInput) => {
+                let len = self.state.denylist_input.len();
+                self.state
+                    .denylist_input
+                    .truncate(len.saturating_sub(byte_count));
+            }
+            None => {}
+        }
+    }
+
+    fn active_field_text(&self) -> &str {
+        match self.state.active_field {
+            Some(ActiveField::AllowlistInput) => &self.state.allowlist_input,
+            Some(ActiveField::DenylistInput) => &self.state.denylist_input,
+            None => "",
+        }
+    }
+
+    const fn set_active_field(&mut self, field: Option<ActiveField>) {
+        self.state.active_field = field;
+        self.ime_marked_byte_count = 0;
+    }
+
+    const fn cycle_active_field(&mut self) {
+        let next = match self.state.active_field {
+            Some(ActiveField::AllowlistInput) => ActiveField::DenylistInput,
+            Some(ActiveField::DenylistInput) | None => ActiveField::AllowlistInput,
+        };
+        self.set_active_field(Some(next));
+    }
+
+    fn emit_set_yolo_mode(&self, enabled: bool) {
+        self.emit(&UserEvent::SetToolApprovalYoloMode { enabled });
+    }
+
+    fn emit_set_auto_approve_reads(&self, enabled: bool) {
+        self.emit(&UserEvent::SetToolApprovalAutoApproveReads { enabled });
+    }
+
+    fn emit_set_mcp_approval_mode(&self, mode: McpApprovalMode) {
+        self.emit(&UserEvent::SetToolApprovalMcpApprovalMode { mode });
+    }
+
+    fn add_allowlist_entry(&mut self) {
+        let prefix = self.state.allowlist_input.trim().to_string();
+        if prefix.is_empty() {
+            return;
+        }
+
+        self.emit(&UserEvent::AddToolApprovalAllowlistPrefix { prefix });
+    }
+
+    fn remove_allowlist_entry(&self, prefix: String) {
+        self.emit(&UserEvent::RemoveToolApprovalAllowlistPrefix { prefix });
+    }
+
+    fn add_denylist_entry(&mut self) {
+        let prefix = self.state.denylist_input.trim().to_string();
+        if prefix.is_empty() {
+            return;
+        }
+
+        self.emit(&UserEvent::AddToolApprovalDenylistPrefix { prefix });
+    }
+
+    fn remove_denylist_entry(&self, prefix: String) {
+        self.emit(&UserEvent::RemoveToolApprovalDenylistPrefix { prefix });
+    }
+
     fn select_profile_by_index(&mut self, index: usize, emit_event: bool) {
         if let Some(profile) = self.state.profiles.get(index) {
             self.state.selected_profile_id = Some(profile.id);
@@ -396,41 +534,109 @@ impl SettingsView {
 
         if key == "escape" || (modifiers.platform && key == "w") {
             Self::navigate_to_chat();
-        } else if key == "=" && modifiers.shift {
+            return;
+        }
+
+        if modifiers.platform && key == "v" {
+            if let Some(item) = cx.read_from_clipboard() {
+                if let Some(text) = item.text() {
+                    self.append_to_active_field(&text);
+                    cx.notify();
+                }
+            }
+            return;
+        }
+
+        if modifiers.platform || modifiers.control {
+            return;
+        }
+
+        if key == "backspace" {
+            self.backspace_active_field();
+            cx.notify();
+            return;
+        }
+
+        if key == "tab" {
+            self.cycle_active_field();
+            cx.notify();
+            return;
+        }
+
+        if key == "=" && modifiers.shift {
             Self::navigate_to_profile_editor();
-        } else if key == "e" && !modifiers.platform {
+            return;
+        }
+
+        if key == "e" {
             self.edit_selected_profile();
-        } else if key == "m" && !modifiers.platform {
+            return;
+        }
+
+        if key == "m" {
             Self::navigate_to_mcp_add();
-        } else if key == "up" && !modifiers.platform {
+            return;
+        }
+
+        if key == "up" {
             self.scroll_profiles(-1);
             self.scroll_themes(-1);
             cx.notify();
-        } else if key == "down" && !modifiers.platform {
+            return;
+        }
+
+        if key == "down" {
             self.scroll_profiles(1);
             self.scroll_themes(1);
             cx.notify();
-        } else if (key == "enter" || key == "space") && !modifiers.platform {
-            if self.state.available_themes.is_empty() {
+            return;
+        }
+
+        if key == "enter" {
+            self.handle_enter_key(cx);
+            return;
+        }
+
+        if key == "space" {
+            self.apply_selected_theme(cx);
+        }
+    }
+
+    fn handle_enter_key(&mut self, cx: &mut gpui::Context<Self>) {
+        match self.state.active_field {
+            Some(ActiveField::AllowlistInput) => {
+                self.add_allowlist_entry();
+                cx.notify();
                 return;
             }
-
-            let selected_slug = self
-                .state
-                .available_themes
-                .iter()
-                .find(|theme| theme.slug == self.state.selected_theme_slug)
-                .map(|theme| theme.slug.clone())
-                .or_else(|| {
-                    self.state
-                        .available_themes
-                        .first()
-                        .map(|theme| theme.slug.clone())
-                });
-
-            if let Some(slug) = selected_slug {
-                self.select_theme(slug, cx);
+            Some(ActiveField::DenylistInput) => {
+                self.add_denylist_entry();
+                cx.notify();
+                return;
             }
+            None => {}
+        }
+        self.apply_selected_theme(cx);
+    }
+
+    fn apply_selected_theme(&mut self, cx: &mut gpui::Context<Self>) {
+        if self.state.available_themes.is_empty() {
+            return;
+        }
+        let selected_slug = self
+            .state
+            .available_themes
+            .iter()
+            .find(|theme| theme.slug == self.state.selected_theme_slug)
+            .map(|theme| theme.slug.clone())
+            .or_else(|| {
+                self.state
+                    .available_themes
+                    .first()
+                    .map(|theme| theme.slug.clone())
+            });
+        if let Some(slug) = selected_slug {
+            self.select_theme(slug, cx);
         }
     }
 
@@ -447,467 +653,103 @@ impl SettingsView {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    #![allow(clippy::future_not_send)]
-
-    use super::*;
-    use crate::presentation::view_command::{ViewCommand, ViewId};
-    use gpui::AppContext;
-    use gpui::TestAppContext;
-
-    fn clear_navigation_requests() {
-        while crate::ui_gpui::navigation_channel()
-            .take_pending()
-            .is_some()
-        {}
+impl gpui::EntityInputHandler for SettingsView {
+    fn text_for_range(
+        &mut self,
+        range: Range<usize>,
+        _adjusted_range: &mut Option<Range<usize>>,
+        _window: &mut Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<String> {
+        let text = self.active_field_text();
+        let utf16: Vec<u16> = text.encode_utf16().collect();
+        let start = range.start.min(utf16.len());
+        let end = range.end.min(utf16.len());
+        String::from_utf16(&utf16[start..end]).ok()
     }
 
-    fn make_bridge() -> (Arc<GpuiBridge>, flume::Receiver<UserEvent>) {
-        let (user_tx, user_rx) = flume::bounded(16);
-        let (_view_tx, view_rx) = flume::bounded(16);
-        (Arc::new(GpuiBridge::new(user_tx, view_rx)), user_rx)
+    fn selected_text_range(
+        &mut self,
+        _ignore_disabled_input: bool,
+        _window: &mut Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<gpui::UTF16Selection> {
+        let len16 = self.active_field_text().encode_utf16().count();
+        Some(gpui::UTF16Selection {
+            range: len16..len16,
+            reversed: false,
+        })
     }
 
-    use flume;
-
-    fn profile_summary(
-        id: Uuid,
-        name: &str,
-        provider: &str,
-        model: &str,
-        is_default: bool,
-    ) -> ProfileSummary {
-        ProfileSummary {
-            id,
-            name: name.to_string(),
-            provider_id: provider.to_string(),
-            model_id: model.to_string(),
-            is_default,
+    fn marked_text_range(
+        &self,
+        _window: &mut Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<Range<usize>> {
+        if self.ime_marked_byte_count > 0 {
+            let text = self.active_field_text();
+            let len16: usize = text.encode_utf16().count();
+            let start_utf8 = text.len().saturating_sub(self.ime_marked_byte_count);
+            let start_utf16: usize = text[..start_utf8].encode_utf16().count();
+            Some(start_utf16..len16)
+        } else {
+            None
         }
     }
 
-    #[gpui::test]
-    async fn handle_command_applies_profile_summaries_and_selection_fallbacks(
-        cx: &mut gpui::TestAppContext,
+    fn unmark_text(&mut self, _window: &mut Window, _cx: &mut gpui::Context<Self>) {
+        self.ime_marked_byte_count = 0;
+    }
+
+    fn replace_text_in_range(
+        &mut self,
+        _range: Option<Range<usize>>,
+        text: &str,
+        _window: &mut Window,
+        cx: &mut gpui::Context<Self>,
     ) {
-        let profile_a = Uuid::new_v4();
-        let profile_b = Uuid::new_v4();
-        let profile_c = Uuid::new_v4();
-        let view = cx.new(SettingsView::new);
-
-        view.update(cx, |view: &mut SettingsView, cx| {
-            view.handle_command(
-                ViewCommand::ShowSettings {
-                    profiles: vec![
-                        profile_summary(profile_a, "Alpha", "openai", "gpt-4o", false),
-                        profile_summary(profile_b, "Beta", "anthropic", "claude", true),
-                    ],
-                    selected_profile_id: None,
-                },
-                cx,
-            );
-
-            assert_eq!(view.state.selected_profile_id, Some(profile_a));
-            assert_eq!(view.state.profiles.len(), 2);
-            assert_eq!(
-                view.state.profiles[0].display_text(),
-                "Alpha (openai:gpt-4o)"
-            );
-            assert_eq!(
-                view.state.profiles[1].display_text(),
-                "Beta (anthropic:claude)"
-            );
-            assert!(view.state.profiles[1].is_default);
-
-            view.handle_command(
-                ViewCommand::ChatProfilesUpdated {
-                    profiles: vec![
-                        profile_summary(profile_b, "Beta", "anthropic", "claude", true),
-                        profile_summary(profile_c, "Gamma", "openai", "gpt-4.1", false),
-                    ],
-                    selected_profile_id: Some(profile_b),
-                },
-                cx,
-            );
-
-            assert_eq!(view.state.selected_profile_id, Some(profile_b));
-            assert_eq!(view.state.profiles.len(), 2);
-
-            view.handle_command(
-                ViewCommand::ShowSettings {
-                    profiles: vec![profile_summary(
-                        profile_c, "Gamma", "openai", "gpt-4.1", false,
-                    )],
-                    selected_profile_id: Some(profile_b),
-                },
-                cx,
-            );
-
-            assert_eq!(view.state.selected_profile_id, Some(profile_c));
-            assert_eq!(view.state.profiles.len(), 1);
-            assert_eq!(view.state.profiles[0].name, "Gamma");
-        });
+        self.remove_trailing_bytes_from_active_field(self.ime_marked_byte_count);
+        self.ime_marked_byte_count = 0;
+        self.append_to_active_field(text);
+        cx.notify();
     }
 
-    #[gpui::test]
-    async fn scroll_profiles_clamps_and_emits_selection_events(cx: &mut gpui::TestAppContext) {
-        let profile_a = Uuid::new_v4();
-        let profile_b = Uuid::new_v4();
-        let (user_tx, user_rx) = flume::bounded(16);
-        let (_view_tx, view_rx) = flume::bounded(16);
-        let bridge = Arc::new(GpuiBridge::new(user_tx, view_rx));
-        let view = cx.new(SettingsView::new);
-
-        view.update(cx, |view: &mut SettingsView, _cx| {
-            view.set_bridge(Arc::clone(&bridge));
-            view.set_profiles(vec![
-                ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
-                ProfileItem::new(profile_b, "Beta").with_model("anthropic", "claude"),
-            ]);
-            view.state.selected_profile_id = Some(profile_a);
-
-            view.scroll_profiles(1);
-            assert_eq!(view.state.selected_profile_id, Some(profile_b));
-            view.scroll_profiles(20);
-            assert_eq!(view.state.selected_profile_id, Some(profile_b));
-            view.scroll_profiles(-20);
-            assert_eq!(view.state.selected_profile_id, Some(profile_a));
-        });
-
-        assert_eq!(
-            user_rx.recv().expect("profile scroll selects beta"),
-            UserEvent::SelectProfile { id: profile_b }
-        );
-        assert_eq!(
-            user_rx.recv().expect("profile scroll returns to alpha"),
-            UserEvent::SelectProfile { id: profile_b }
-        );
-        assert_eq!(
-            user_rx.recv().expect("profile scroll selects alpha"),
-            UserEvent::SelectProfile { id: profile_a }
-        );
-        assert!(
-            user_rx.try_recv().is_err(),
-            "settings view test should emit only expected bridge events"
-        );
-    }
-
-    #[gpui::test]
-    async fn mcp_commands_update_status_lifecycle_and_selection(cx: &mut gpui::TestAppContext) {
-        let mcp_existing = Uuid::new_v4();
-        let mcp_new = Uuid::new_v4();
-        let view = cx.new(SettingsView::new);
-
-        view.update(cx, |view: &mut SettingsView, cx| {
-            view.set_mcps(vec![
-                McpItem::new(mcp_existing, "Existing").with_status(McpStatus::Stopped)
-            ]);
-            assert_eq!(view.state.selected_mcp_id, Some(mcp_existing));
-
-            view.handle_command(
-                ViewCommand::McpStatusChanged {
-                    id: mcp_existing,
-                    status: crate::presentation::view_command::McpStatus::Running,
-                },
-                cx,
-            );
-            let existing = view
-                .state
-                .mcps
-                .iter()
-                .find(|m| m.id == mcp_existing)
-                .unwrap();
-            assert_eq!(existing.status, McpStatus::Running);
-            assert!(existing.enabled);
-
-            view.handle_command(
-                ViewCommand::McpServerStarted {
-                    id: mcp_new,
-                    name: Some("Fetch".to_string()),
-                    tool_count: 3,
-                    enabled: Some(false),
-                },
-                cx,
-            );
-            let inserted = view.state.mcps.iter().find(|m| m.id == mcp_new).unwrap();
-            assert_eq!(inserted.name, "Fetch");
-            assert!(!inserted.enabled);
-            assert_eq!(inserted.status, McpStatus::Stopped);
-
-            view.handle_command(
-                ViewCommand::McpServerFailed {
-                    id: mcp_new,
-                    error: "boom".to_string(),
-                },
-                cx,
-            );
-            let failed = view.state.mcps.iter().find(|m| m.id == mcp_new).unwrap();
-            assert_eq!(failed.status, McpStatus::Error);
-            assert!(!failed.enabled);
-
-            view.handle_command(
-                ViewCommand::McpConfigSaved {
-                    id: mcp_new,
-                    name: Some("Saved MCP".to_string()),
-                },
-                cx,
-            );
-            let saved = view.state.mcps.iter().find(|m| m.id == mcp_new).unwrap();
-            assert_eq!(view.state.selected_mcp_id, Some(mcp_new));
-            assert_eq!(saved.name, "Saved MCP");
-            assert!(saved.enabled);
-            assert_eq!(saved.status, McpStatus::Stopped);
-
-            view.handle_command(ViewCommand::McpDeleted { id: mcp_new }, cx);
-            assert!(view.state.mcps.iter().all(|m| m.id != mcp_new));
-        });
-    }
-
-    #[gpui::test]
-    async fn profile_and_mcp_setters_enforce_selection_fallbacks_without_bridge(
-        cx: &mut gpui::TestAppContext,
+    fn replace_and_mark_text_in_range(
+        &mut self,
+        _range: Option<Range<usize>>,
+        new_text: &str,
+        _new_selected_range: Option<Range<usize>>,
+        _window: &mut Window,
+        cx: &mut gpui::Context<Self>,
     ) {
-        let profile_a = Uuid::new_v4();
-        let profile_b = Uuid::new_v4();
-        let profile_c = Uuid::new_v4();
-        let mcp_a = Uuid::new_v4();
-        let mcp_b = Uuid::new_v4();
-        let mcp_c = Uuid::new_v4();
-        let view = cx.new(SettingsView::new);
-
-        view.update(cx, |view: &mut SettingsView, _cx| {
-            view.set_profiles(vec![
-                ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
-                ProfileItem::new(profile_b, "Beta").with_model("anthropic", "claude"),
-            ]);
-            assert_eq!(view.state.selected_profile_id, None);
-
-            view.state.selected_profile_id = Some(profile_a);
-            view.set_profiles(vec![
-                ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
-                ProfileItem::new(profile_c, "Gamma").with_model("openai", "gpt-4.1"),
-            ]);
-            assert_eq!(view.state.selected_profile_id, Some(profile_a));
-            assert_eq!(view.state.profiles.len(), 2);
-            assert_eq!(
-                view.state.profiles[1].display_text(),
-                "Gamma (openai:gpt-4.1)"
-            );
-
-            view.state.selected_profile_id = Some(profile_b);
-            view.set_profiles(vec![
-                ProfileItem::new(profile_c, "Gamma").with_model("openai", "gpt-4.1")
-            ]);
-            assert_eq!(view.state.selected_profile_id, Some(profile_b));
-
-            view.set_mcps(vec![
-                McpItem::new(mcp_a, "Existing").with_status(McpStatus::Stopped),
-                McpItem::new(mcp_b, "Runner").with_enabled(true),
-            ]);
-            assert_eq!(view.state.selected_mcp_id, Some(mcp_a));
-
-            view.state.selected_mcp_id = Some(mcp_b);
-            view.set_mcps(vec![
-                McpItem::new(mcp_b, "Runner").with_enabled(true),
-                McpItem::new(mcp_c, "Fetcher").with_status(McpStatus::Error),
-            ]);
-            assert_eq!(view.state.selected_mcp_id, Some(mcp_b));
-            assert_eq!(view.state.mcps[0].status, McpStatus::Running);
-            assert_eq!(view.state.mcps[1].status, McpStatus::Error);
-
-            view.state.selected_mcp_id = Some(mcp_a);
-            view.set_mcps(vec![
-                McpItem::new(mcp_c, "Fetcher").with_status(McpStatus::Error)
-            ]);
-            assert_eq!(view.state.selected_mcp_id, Some(mcp_c));
-            assert_eq!(view.state.mcps.len(), 1);
-            assert!(!view.state.mcps[0].enabled);
-        });
-    }
-
-    fn settings_key_event(key: &str) -> gpui::KeyDownEvent {
-        gpui::KeyDownEvent {
-            keystroke: gpui::Keystroke::parse(key).unwrap_or_else(|_| panic!("{key} keystroke")),
-            is_held: false,
-            prefer_character_input: false,
+        self.remove_trailing_bytes_from_active_field(self.ime_marked_byte_count);
+        self.ime_marked_byte_count = 0;
+        if !new_text.is_empty() {
+            self.append_to_active_field(new_text);
+            self.ime_marked_byte_count = new_text.len();
         }
+        cx.notify();
     }
 
-    #[gpui::test]
-    async fn helper_actions_emit_expected_bridge_events(cx: &mut TestAppContext) {
-        clear_navigation_requests();
-        let profile_a = Uuid::new_v4();
-        let profile_b = Uuid::new_v4();
-        let mcp_a = Uuid::new_v4();
-        let (bridge, user_rx) = make_bridge();
-        let view = cx.new(SettingsView::new);
-
-        view.update(cx, |view: &mut SettingsView, cx| {
-            view.set_bridge(Arc::clone(&bridge));
-            view.set_profiles(vec![
-                ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
-                ProfileItem::new(profile_b, "Beta").with_model("anthropic", "claude"),
-            ]);
-            view.set_mcps(vec![McpItem::new(mcp_a, "Fetcher").with_enabled(true)]);
-            view.state.selected_profile_id = Some(profile_a);
-            view.state.selected_mcp_id = Some(mcp_a);
-
-            view.select_profile(profile_b, cx);
-            assert_eq!(view.state.selected_profile_id, Some(profile_b));
-
-            view.delete_selected_profile();
-            view.edit_selected_profile();
-
-            view.toggle_mcp(mcp_a, false);
-            view.select_mcp(mcp_a, cx);
-            assert_eq!(view.state.selected_mcp_id, Some(mcp_a));
-            view.delete_selected_mcp();
-            view.edit_selected_mcp();
-            assert_eq!(
-                crate::ui_gpui::navigation_channel().take_pending(),
-                Some(ViewId::McpConfigure)
-            );
-        });
-
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::SelectProfile { id: profile_b }
-        );
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::DeleteProfile { id: profile_b }
-        );
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::EditProfile { id: profile_b }
-        );
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::ToggleMcp {
-                id: mcp_a,
-                enabled: false
-            }
-        );
-        assert_eq!(user_rx.recv().unwrap(), UserEvent::DeleteMcp { id: mcp_a });
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::ConfigureMcp { id: mcp_a }
-        );
-        assert!(
-            user_rx.try_recv().is_err(),
-            "unexpected additional settings events"
-        );
+    fn bounds_for_range(
+        &mut self,
+        _range: Range<usize>,
+        _element_bounds: Bounds<Pixels>,
+        _window: &mut Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<Bounds<Pixels>> {
+        None
     }
 
-    #[gpui::test]
-    async fn key_handling_navigates_and_emits_profile_events(cx: &mut TestAppContext) {
-        clear_navigation_requests();
-        let profile_a = Uuid::new_v4();
-        let profile_b = Uuid::new_v4();
-        let mcp_a = Uuid::new_v4();
-        let (bridge, user_rx) = make_bridge();
-        let view = cx.new(SettingsView::new);
-
-        view.update(cx, |view: &mut SettingsView, cx| {
-            view.set_bridge(Arc::clone(&bridge));
-            view.set_profiles(vec![
-                ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
-                ProfileItem::new(profile_b, "Beta").with_model("anthropic", "claude"),
-            ]);
-            view.set_mcps(vec![McpItem::new(mcp_a, "Fetcher").with_enabled(true)]);
-            view.state.selected_profile_id = Some(profile_b);
-
-            view.handle_key_down(&settings_key_event("up"), cx);
-            assert_eq!(view.state.selected_profile_id, Some(profile_a));
-
-            view.handle_key_down(&settings_key_event("down"), cx);
-            assert_eq!(view.state.selected_profile_id, Some(profile_b));
-
-            view.handle_key_down(&settings_key_event("e"), cx);
-
-            view.handle_key_down(&settings_key_event("shift-="), cx);
-            assert_eq!(
-                crate::ui_gpui::navigation_channel().take_pending(),
-                Some(ViewId::ProfileEditor)
-            );
-
-            view.handle_key_down(&settings_key_event("m"), cx);
-            assert_eq!(
-                crate::ui_gpui::navigation_channel().take_pending(),
-                Some(ViewId::McpAdd)
-            );
-
-            view.state.available_themes = vec![
-                ThemeOption {
-                    name: "Green Screen".to_string(),
-                    slug: "green-screen".to_string(),
-                },
-                ThemeOption {
-                    name: "Midnight Nebula".to_string(),
-                    slug: "default".to_string(),
-                },
-            ];
-            view.state.selected_theme_slug = "green-screen".to_string();
-            view.handle_key_down(&settings_key_event("down"), cx);
-            assert_eq!(view.state.selected_theme_slug, "default");
-            view.handle_key_down(&settings_key_event("enter"), cx);
-
-            view.handle_key_down(&settings_key_event("cmd-w"), cx);
-            assert_eq!(
-                crate::ui_gpui::navigation_channel().take_pending(),
-                Some(ViewId::Chat)
-            );
-        });
-
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::SelectProfile { id: profile_a }
-        );
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::SelectProfile { id: profile_b }
-        );
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::EditProfile { id: profile_b }
-        );
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::SelectProfile { id: profile_b }
-        );
-        assert_eq!(
-            user_rx.recv().unwrap(),
-            UserEvent::SelectTheme {
-                slug: "default".to_string()
-            }
-        );
-        assert!(
-            user_rx.try_recv().is_err(),
-            "unexpected additional settings events"
-        );
-    }
-
-    #[gpui::test]
-    async fn static_navigation_helpers_route_to_expected_views(_cx: &mut TestAppContext) {
-        clear_navigation_requests();
-
-        SettingsView::navigate_to_profile_editor();
-        assert_eq!(
-            crate::ui_gpui::navigation_channel().take_pending(),
-            Some(ViewId::ProfileEditor)
-        );
-
-        SettingsView::navigate_to_mcp_add();
-        assert_eq!(
-            crate::ui_gpui::navigation_channel().take_pending(),
-            Some(ViewId::McpAdd)
-        );
-
-        SettingsView::navigate_to_chat();
-        assert_eq!(
-            crate::ui_gpui::navigation_channel().take_pending(),
-            Some(ViewId::Chat)
-        );
+    fn character_index_for_point(
+        &mut self,
+        _point: gpui::Point<Pixels>,
+        _window: &mut Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<usize> {
+        None
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/ui_gpui/views/settings_view/render.rs
+++ b/src/ui_gpui/views/settings_view/render.rs
@@ -3,7 +3,10 @@
 use super::{McpItem, McpStatus, ProfileItem, SettingsView};
 use crate::events::types::UserEvent;
 use crate::ui_gpui::theme::Theme;
-use gpui::{div, prelude::*, px, FontWeight, MouseButton, SharedString};
+use gpui::{
+    canvas, div, prelude::*, px, Bounds, ElementInputHandler, FontWeight, MouseButton, Pixels,
+    SharedString,
+};
 
 impl SettingsView {
     /// Render the top bar with back button and title
@@ -621,6 +624,27 @@ impl gpui::Render for SettingsView {
             .size_full()
             .bg(Theme::bg_darkest())
             .track_focus(&self.focus_handle)
+            // Invisible canvas for InputHandler registration (IME/diacritics)
+            .child(
+                canvas(
+                    |bounds, _window: &mut gpui::Window, _cx: &mut gpui::App| bounds,
+                    {
+                        let entity = cx.entity();
+                        let focus = self.focus_handle.clone();
+                        move |bounds: Bounds<Pixels>,
+                              _,
+                              window: &mut gpui::Window,
+                              cx: &mut gpui::App| {
+                            window.handle_input(
+                                &focus,
+                                ElementInputHandler::new(bounds, entity),
+                                cx,
+                            );
+                        }
+                    },
+                )
+                .size_0(),
+            )
             .on_key_down(
                 cx.listener(|this, event: &gpui::KeyDownEvent, _window, cx| {
                     this.handle_key_down(event, cx);
@@ -631,17 +655,20 @@ impl gpui::Render for SettingsView {
             // Content scroll area
             .child(
                 div()
+                    .id("settings-scroll-area")
                     .flex_1()
                     .w_full()
                     .p(px(12.0))
                     .flex()
                     .flex_col()
                     .gap(px(16.0))
-                    .overflow_hidden()
+                    .overflow_y_scroll()
                     // Profiles section
                     .child(self.render_profiles_section(cx))
                     // MCP Tools section
                     .child(self.render_mcp_section(cx))
+                    // Tool approval section
+                    .child(self.render_tool_approval_section(cx))
                     // Theme section
                     .child(self.render_theme_section(cx)),
             )

--- a/src/ui_gpui/views/settings_view/render_tool_approval.rs
+++ b/src/ui_gpui/views/settings_view/render_tool_approval.rs
@@ -1,0 +1,406 @@
+//! Tool approval section rendering for `SettingsView`.
+
+use std::sync::Arc;
+
+use super::{ActiveField, SettingsView};
+use crate::agent::McpApprovalMode;
+use crate::ui_gpui::theme::Theme;
+use gpui::{div, prelude::*, px, MouseButton, SharedString};
+
+impl SettingsView {
+    fn render_toggle(
+        id: &str,
+        label: &str,
+        checked: bool,
+        cx: &mut gpui::Context<Self>,
+        on_toggle: impl Fn(&mut Self, &mut gpui::Context<Self>) + 'static,
+    ) -> impl IntoElement {
+        div()
+            .id(SharedString::from(id.to_string()))
+            .flex()
+            .items_center()
+            .gap(px(8.0))
+            .cursor_pointer()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, _window, cx| {
+                    on_toggle(this, cx);
+                }),
+            )
+            .child(
+                div()
+                    .size(px(14.0))
+                    .border_1()
+                    .border_color(Theme::border())
+                    .rounded(px(2.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .when(checked, |d| {
+                        d.bg(Theme::accent()).child(
+                            div()
+                                .text_size(px(9.0))
+                                .text_color(gpui::white())
+                                .child("v"),
+                        )
+                    }),
+            )
+            .child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(Theme::text_primary())
+                    .child(label.to_string()),
+            )
+    }
+
+    #[allow(clippy::unused_self)]
+    fn render_prefix_list(
+        &self,
+        id_prefix: &str,
+        entries: &[String],
+        on_remove: impl Fn(&mut Self, String) + 'static,
+        cx: &mut gpui::Context<Self>,
+    ) -> impl IntoElement {
+        let on_remove = Arc::new(on_remove);
+        div()
+            .id(SharedString::from(format!("{id_prefix}-list")))
+            .w_full()
+            .min_h(px(32.0))
+            .max_h(px(80.0))
+            .bg(Theme::bg_darker())
+            .border_1()
+            .border_color(Theme::border())
+            .rounded(px(4.0))
+            .overflow_y_scroll()
+            .flex()
+            .flex_col()
+            .when(entries.is_empty(), |d| {
+                d.items_center().justify_center().child(
+                    div()
+                        .text_size(px(11.0))
+                        .text_color(Theme::text_muted())
+                        .child("(none)"),
+                )
+            })
+            .children(entries.iter().enumerate().map(|(i, entry)| {
+                let entry_clone = entry.clone();
+                let remove = Arc::clone(&on_remove);
+                div()
+                    .id(SharedString::from(format!("{id_prefix}-entry-{i}")))
+                    .w_full()
+                    .h(px(24.0))
+                    .px(px(8.0))
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .hover(|s| s.bg(Theme::bg_dark()))
+                    .child(
+                        div()
+                            .flex_1()
+                            .text_size(px(12.0))
+                            .text_color(Theme::text_primary())
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .child(entry.clone()),
+                    )
+                    .child(
+                        div()
+                            .id(SharedString::from(format!("{id_prefix}-rm-{i}")))
+                            .size(px(18.0))
+                            .rounded(px(2.0))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .cursor_pointer()
+                            .hover(|s| s.bg(Theme::danger()))
+                            .text_size(px(11.0))
+                            .text_color(Theme::text_muted())
+                            .child("x")
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, _, _window, _cx| {
+                                    remove(this, entry_clone.clone());
+                                }),
+                            ),
+                    )
+                    .into_any_element()
+            }))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn render_input_row(
+        id: &str,
+        value: &str,
+        placeholder: &str,
+        is_active: bool,
+        on_focus: impl Fn(&mut Self, &mut gpui::Context<Self>) + 'static,
+        on_add: impl Fn(&mut Self, &mut gpui::Context<Self>) + 'static,
+        cx: &mut gpui::Context<Self>,
+    ) -> impl IntoElement {
+        div()
+            .flex()
+            .items_center()
+            .gap(px(4.0))
+            .child(
+                div()
+                    .id(SharedString::from(format!("{id}-field")))
+                    .flex_1()
+                    .h(px(24.0))
+                    .px(px(8.0))
+                    .bg(Theme::bg_dark())
+                    .border_1()
+                    .border_color(if is_active {
+                        Theme::accent()
+                    } else {
+                        Theme::border()
+                    })
+                    .rounded(px(4.0))
+                    .flex()
+                    .items_center()
+                    .text_size(px(12.0))
+                    .overflow_hidden()
+                    .cursor_text()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, _window, cx| {
+                            on_focus(this, cx);
+                        }),
+                    )
+                    .child(if value.is_empty() {
+                        div()
+                            .text_color(Theme::text_muted())
+                            .child(placeholder.to_string())
+                    } else {
+                        div()
+                            .text_color(Theme::text_primary())
+                            .child(value.to_string())
+                    }),
+            )
+            .child(
+                div()
+                    .id(SharedString::from(format!("{id}-add-btn")))
+                    .h(px(24.0))
+                    .px(px(8.0))
+                    .bg(Theme::bg_dark())
+                    .border_1()
+                    .border_color(Theme::border())
+                    .rounded(px(4.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .cursor_pointer()
+                    .hover(|s| s.bg(Theme::accent()))
+                    .text_size(px(11.0))
+                    .text_color(Theme::text_primary())
+                    .child("Add")
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, _window, cx| {
+                            on_add(this, cx);
+                        }),
+                    ),
+            )
+    }
+
+    fn render_mcp_mode_selector(
+        mcp_mode: McpApprovalMode,
+        cx: &mut gpui::Context<Self>,
+    ) -> impl IntoElement {
+        let mode_button =
+            |id: &str, label: &str, target: McpApprovalMode, cx: &mut gpui::Context<Self>| {
+                let is_selected = mcp_mode == target;
+                div()
+                    .id(SharedString::from(id.to_string()))
+                    .px(px(8.0))
+                    .py(px(2.0))
+                    .rounded(px(4.0))
+                    .cursor_pointer()
+                    .border_1()
+                    .border_color(if is_selected {
+                        Theme::accent()
+                    } else {
+                        Theme::border()
+                    })
+                    .when(is_selected, |d| {
+                        d.bg(Theme::selection_bg())
+                            .text_color(Theme::selection_fg())
+                    })
+                    .when(!is_selected, |d| {
+                        d.bg(Theme::bg_dark())
+                            .text_color(Theme::text_primary())
+                            .hover(|s| s.bg(Theme::bg_darker()))
+                    })
+                    .text_size(px(11.0))
+                    .child(label.to_string())
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, _window, _cx| {
+                            this.emit_set_mcp_approval_mode(target);
+                        }),
+                    )
+            };
+
+        div()
+            .flex()
+            .items_center()
+            .gap(px(8.0))
+            .child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(Theme::text_primary())
+                    .child("MCP approval:"),
+            )
+            .child(mode_button(
+                "mcp-mode-per-tool",
+                "Per Tool",
+                McpApprovalMode::PerTool,
+                cx,
+            ))
+            .child(mode_button(
+                "mcp-mode-per-server",
+                "Per Server",
+                McpApprovalMode::PerServer,
+                cx,
+            ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn render_editable_list_section(
+        &self,
+        label: &str,
+        id_prefix: &str,
+        entries: &[String],
+        input: &str,
+        placeholder: &str,
+        field: ActiveField,
+        on_remove: impl Fn(&mut Self, String) + 'static,
+        on_add: impl Fn(&mut Self, &mut gpui::Context<Self>) + 'static,
+        cx: &mut gpui::Context<Self>,
+    ) -> impl IntoElement {
+        let is_active = self.state.active_field == Some(field);
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(4.0))
+            .child(
+                div()
+                    .text_size(px(11.0))
+                    .text_color(Theme::text_muted())
+                    .child(label.to_string()),
+            )
+            .child(self.render_prefix_list(id_prefix, entries, on_remove, cx))
+            .child(Self::render_input_row(
+                id_prefix,
+                input,
+                placeholder,
+                is_active,
+                move |this, cx| {
+                    this.set_active_field(Some(field));
+                    cx.notify();
+                },
+                on_add,
+                cx,
+            ))
+    }
+
+    pub(super) fn render_tool_approval_section(
+        &self,
+        cx: &mut gpui::Context<Self>,
+    ) -> impl IntoElement {
+        let yolo = self.state.yolo_mode;
+        let reads = self.state.auto_approve_reads;
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(6.0))
+            .child(
+                div()
+                    .text_size(px(11.0))
+                    .text_color(Theme::text_primary())
+                    .child("TOOL APPROVAL"),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(4.0))
+                    .child(Self::render_toggle(
+                        "toggle-yolo",
+                        "YOLO mode",
+                        yolo,
+                        cx,
+                        |this, _cx| this.emit_set_yolo_mode(!this.state.yolo_mode),
+                    ))
+                    .when(yolo, |d| {
+                        d.child(
+                            div()
+                                .px(px(22.0))
+                                .text_size(px(10.0))
+                                .text_color(Theme::warning())
+                                .child("Auto-approves all tool calls except denylisted commands."),
+                        )
+                    }),
+            )
+            .child(Self::render_toggle(
+                "toggle-reads",
+                "Auto-approve read-only tools",
+                reads,
+                cx,
+                |this, _cx| this.emit_set_auto_approve_reads(!this.state.auto_approve_reads),
+            ))
+            .child(Self::render_mcp_mode_selector(
+                self.state.mcp_approval_mode,
+                cx,
+            ))
+            .child(self.render_editable_list_section(
+                "ALLOWLIST",
+                "allowlist",
+                &self.state.persistent_allowlist,
+                &self.state.allowlist_input,
+                "e.g. git, ls, cat",
+                ActiveField::AllowlistInput,
+                |this, prefix| this.remove_allowlist_entry(prefix),
+                |this, cx| {
+                    this.add_allowlist_entry();
+                    cx.notify();
+                },
+                cx,
+            ))
+            .child(self.render_editable_list_section(
+                "DENYLIST",
+                "denylist",
+                &self.state.persistent_denylist,
+                &self.state.denylist_input,
+                "e.g. rm, sudo, shutdown",
+                ActiveField::DenylistInput,
+                |this, prefix| this.remove_denylist_entry(prefix),
+                |this, cx| {
+                    this.add_denylist_entry();
+                    cx.notify();
+                },
+                cx,
+            ))
+            .when_some(self.state.status_message.clone(), |d, msg| {
+                d.child(
+                    div()
+                        .w_full()
+                        .px(px(8.0))
+                        .py(px(4.0))
+                        .rounded(px(4.0))
+                        .bg(if self.state.status_is_error {
+                            Theme::error()
+                        } else {
+                            Theme::bg_dark()
+                        })
+                        .text_size(px(11.0))
+                        .text_color(if self.state.status_is_error {
+                            gpui::white()
+                        } else {
+                            Theme::text_primary()
+                        })
+                        .child(msg),
+                )
+            })
+    }
+}

--- a/src/ui_gpui/views/settings_view/tests.rs
+++ b/src/ui_gpui/views/settings_view/tests.rs
@@ -1,0 +1,833 @@
+#![allow(clippy::future_not_send)]
+
+use super::*;
+use crate::presentation::view_command::{ViewCommand, ViewId};
+use gpui::AppContext;
+use gpui::TestAppContext;
+
+fn clear_navigation_requests() {
+    while crate::ui_gpui::navigation_channel()
+        .take_pending()
+        .is_some()
+    {}
+}
+
+fn make_bridge() -> (Arc<GpuiBridge>, flume::Receiver<UserEvent>) {
+    let (user_tx, user_rx) = flume::bounded(16);
+    let (_view_tx, view_rx) = flume::bounded(16);
+    (Arc::new(GpuiBridge::new(user_tx, view_rx)), user_rx)
+}
+
+use flume;
+
+fn profile_summary(
+    id: Uuid,
+    name: &str,
+    provider: &str,
+    model: &str,
+    is_default: bool,
+) -> ProfileSummary {
+    ProfileSummary {
+        id,
+        name: name.to_string(),
+        provider_id: provider.to_string(),
+        model_id: model.to_string(),
+        is_default,
+    }
+}
+
+#[gpui::test]
+async fn handle_command_applies_profile_summaries_and_selection_fallbacks(
+    cx: &mut gpui::TestAppContext,
+) {
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let profile_c = Uuid::new_v4();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view: &mut SettingsView, cx| {
+        view.handle_command(
+            ViewCommand::ShowSettings {
+                profiles: vec![
+                    profile_summary(profile_a, "Alpha", "openai", "gpt-4o", false),
+                    profile_summary(profile_b, "Beta", "anthropic", "claude", true),
+                ],
+                selected_profile_id: None,
+            },
+            cx,
+        );
+
+        assert_eq!(view.state.selected_profile_id, Some(profile_a));
+        assert_eq!(view.state.profiles.len(), 2);
+        assert_eq!(
+            view.state.profiles[0].display_text(),
+            "Alpha (openai:gpt-4o)"
+        );
+        assert_eq!(
+            view.state.profiles[1].display_text(),
+            "Beta (anthropic:claude)"
+        );
+        assert!(view.state.profiles[1].is_default);
+
+        view.handle_command(
+            ViewCommand::ChatProfilesUpdated {
+                profiles: vec![
+                    profile_summary(profile_b, "Beta", "anthropic", "claude", true),
+                    profile_summary(profile_c, "Gamma", "openai", "gpt-4.1", false),
+                ],
+                selected_profile_id: Some(profile_b),
+            },
+            cx,
+        );
+
+        assert_eq!(view.state.selected_profile_id, Some(profile_b));
+        assert_eq!(view.state.profiles.len(), 2);
+
+        view.handle_command(
+            ViewCommand::ShowSettings {
+                profiles: vec![profile_summary(
+                    profile_c, "Gamma", "openai", "gpt-4.1", false,
+                )],
+                selected_profile_id: Some(profile_b),
+            },
+            cx,
+        );
+
+        assert_eq!(view.state.selected_profile_id, Some(profile_c));
+        assert_eq!(view.state.profiles.len(), 1);
+        assert_eq!(view.state.profiles[0].name, "Gamma");
+    });
+}
+
+#[gpui::test]
+async fn scroll_profiles_clamps_and_emits_selection_events(cx: &mut gpui::TestAppContext) {
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let (user_tx, user_rx) = flume::bounded(16);
+    let (_view_tx, view_rx) = flume::bounded(16);
+    let bridge = Arc::new(GpuiBridge::new(user_tx, view_rx));
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view: &mut SettingsView, _cx| {
+        view.set_bridge(Arc::clone(&bridge));
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
+            ProfileItem::new(profile_b, "Beta").with_model("anthropic", "claude"),
+        ]);
+        view.state.selected_profile_id = Some(profile_a);
+
+        view.scroll_profiles(1);
+        assert_eq!(view.state.selected_profile_id, Some(profile_b));
+        view.scroll_profiles(20);
+        assert_eq!(view.state.selected_profile_id, Some(profile_b));
+        view.scroll_profiles(-20);
+        assert_eq!(view.state.selected_profile_id, Some(profile_a));
+    });
+
+    assert_eq!(
+        user_rx.recv().expect("profile scroll selects beta"),
+        UserEvent::SelectProfile { id: profile_b }
+    );
+    assert_eq!(
+        user_rx.recv().expect("profile scroll returns to alpha"),
+        UserEvent::SelectProfile { id: profile_b }
+    );
+    assert_eq!(
+        user_rx.recv().expect("profile scroll selects alpha"),
+        UserEvent::SelectProfile { id: profile_a }
+    );
+    assert!(
+        user_rx.try_recv().is_err(),
+        "settings view test should emit only expected bridge events"
+    );
+}
+
+#[gpui::test]
+async fn mcp_commands_update_status_lifecycle_and_selection(cx: &mut gpui::TestAppContext) {
+    let mcp_existing = Uuid::new_v4();
+    let mcp_new = Uuid::new_v4();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view: &mut SettingsView, cx| {
+        view.set_mcps(vec![
+            McpItem::new(mcp_existing, "Existing").with_status(McpStatus::Stopped)
+        ]);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_existing));
+
+        view.handle_command(
+            ViewCommand::McpStatusChanged {
+                id: mcp_existing,
+                status: crate::presentation::view_command::McpStatus::Running,
+            },
+            cx,
+        );
+        let existing = view
+            .state
+            .mcps
+            .iter()
+            .find(|m| m.id == mcp_existing)
+            .unwrap();
+        assert_eq!(existing.status, McpStatus::Running);
+        assert!(existing.enabled);
+
+        view.handle_command(
+            ViewCommand::McpServerStarted {
+                id: mcp_new,
+                name: Some("Fetch".to_string()),
+                tool_count: 3,
+                enabled: Some(false),
+            },
+            cx,
+        );
+        let inserted = view.state.mcps.iter().find(|m| m.id == mcp_new).unwrap();
+        assert_eq!(inserted.name, "Fetch");
+        assert!(!inserted.enabled);
+        assert_eq!(inserted.status, McpStatus::Stopped);
+
+        view.handle_command(
+            ViewCommand::McpServerFailed {
+                id: mcp_new,
+                error: "boom".to_string(),
+            },
+            cx,
+        );
+        let failed = view.state.mcps.iter().find(|m| m.id == mcp_new).unwrap();
+        assert_eq!(failed.status, McpStatus::Error);
+        assert!(!failed.enabled);
+
+        view.handle_command(
+            ViewCommand::McpConfigSaved {
+                id: mcp_new,
+                name: Some("Saved MCP".to_string()),
+            },
+            cx,
+        );
+        let saved = view.state.mcps.iter().find(|m| m.id == mcp_new).unwrap();
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_new));
+        assert_eq!(saved.name, "Saved MCP");
+        assert!(saved.enabled);
+        assert_eq!(saved.status, McpStatus::Stopped);
+
+        view.handle_command(ViewCommand::McpDeleted { id: mcp_new }, cx);
+        assert!(view.state.mcps.iter().all(|m| m.id != mcp_new));
+    });
+}
+
+#[gpui::test]
+async fn profile_and_mcp_setters_enforce_selection_fallbacks_without_bridge(
+    cx: &mut gpui::TestAppContext,
+) {
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let profile_c = Uuid::new_v4();
+    let mcp_a = Uuid::new_v4();
+    let mcp_b = Uuid::new_v4();
+    let mcp_c = Uuid::new_v4();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view: &mut SettingsView, _cx| {
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
+            ProfileItem::new(profile_b, "Beta").with_model("anthropic", "claude"),
+        ]);
+        assert_eq!(view.state.selected_profile_id, None);
+
+        view.state.selected_profile_id = Some(profile_a);
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
+            ProfileItem::new(profile_c, "Gamma").with_model("openai", "gpt-4.1"),
+        ]);
+        assert_eq!(view.state.selected_profile_id, Some(profile_a));
+        assert_eq!(view.state.profiles.len(), 2);
+        assert_eq!(
+            view.state.profiles[1].display_text(),
+            "Gamma (openai:gpt-4.1)"
+        );
+
+        view.state.selected_profile_id = Some(profile_b);
+        view.set_profiles(vec![
+            ProfileItem::new(profile_c, "Gamma").with_model("openai", "gpt-4.1")
+        ]);
+        assert_eq!(view.state.selected_profile_id, Some(profile_b));
+
+        view.set_mcps(vec![
+            McpItem::new(mcp_a, "Existing").with_status(McpStatus::Stopped),
+            McpItem::new(mcp_b, "Runner").with_enabled(true),
+        ]);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_a));
+
+        view.state.selected_mcp_id = Some(mcp_b);
+        view.set_mcps(vec![
+            McpItem::new(mcp_b, "Runner").with_enabled(true),
+            McpItem::new(mcp_c, "Fetcher").with_status(McpStatus::Error),
+        ]);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_b));
+        assert_eq!(view.state.mcps[0].status, McpStatus::Running);
+        assert_eq!(view.state.mcps[1].status, McpStatus::Error);
+
+        view.state.selected_mcp_id = Some(mcp_a);
+        view.set_mcps(vec![
+            McpItem::new(mcp_c, "Fetcher").with_status(McpStatus::Error)
+        ]);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_c));
+        assert_eq!(view.state.mcps.len(), 1);
+        assert!(!view.state.mcps[0].enabled);
+    });
+}
+
+fn settings_key_event(key: &str) -> gpui::KeyDownEvent {
+    gpui::KeyDownEvent {
+        keystroke: gpui::Keystroke::parse(key).unwrap_or_else(|_| panic!("{key} keystroke")),
+        is_held: false,
+        prefer_character_input: false,
+    }
+}
+
+#[gpui::test]
+async fn helper_actions_emit_expected_bridge_events(cx: &mut TestAppContext) {
+    clear_navigation_requests();
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let mcp_a = Uuid::new_v4();
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view: &mut SettingsView, cx| {
+        view.set_bridge(Arc::clone(&bridge));
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
+            ProfileItem::new(profile_b, "Beta").with_model("anthropic", "claude"),
+        ]);
+        view.set_mcps(vec![McpItem::new(mcp_a, "Fetcher").with_enabled(true)]);
+        view.state.selected_profile_id = Some(profile_a);
+        view.state.selected_mcp_id = Some(mcp_a);
+
+        view.select_profile(profile_b, cx);
+        assert_eq!(view.state.selected_profile_id, Some(profile_b));
+
+        view.delete_selected_profile();
+        view.edit_selected_profile();
+
+        view.toggle_mcp(mcp_a, false);
+        view.select_mcp(mcp_a, cx);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_a));
+        view.delete_selected_mcp();
+        view.edit_selected_mcp();
+        assert_eq!(
+            crate::ui_gpui::navigation_channel().take_pending(),
+            Some(ViewId::McpConfigure)
+        );
+    });
+
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::SelectProfile { id: profile_b }
+    );
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::DeleteProfile { id: profile_b }
+    );
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::EditProfile { id: profile_b }
+    );
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::ToggleMcp {
+            id: mcp_a,
+            enabled: false
+        }
+    );
+    assert_eq!(user_rx.recv().unwrap(), UserEvent::DeleteMcp { id: mcp_a });
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::ConfigureMcp { id: mcp_a }
+    );
+    assert!(
+        user_rx.try_recv().is_err(),
+        "unexpected additional settings events"
+    );
+}
+
+#[gpui::test]
+async fn key_handling_navigates_and_emits_profile_events(cx: &mut TestAppContext) {
+    clear_navigation_requests();
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let mcp_a = Uuid::new_v4();
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view: &mut SettingsView, cx| {
+        view.set_bridge(Arc::clone(&bridge));
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha").with_model("openai", "gpt-4o"),
+            ProfileItem::new(profile_b, "Beta").with_model("anthropic", "claude"),
+        ]);
+        view.set_mcps(vec![McpItem::new(mcp_a, "Fetcher").with_enabled(true)]);
+        view.state.selected_profile_id = Some(profile_b);
+
+        view.handle_key_down(&settings_key_event("up"), cx);
+        assert_eq!(view.state.selected_profile_id, Some(profile_a));
+
+        view.handle_key_down(&settings_key_event("down"), cx);
+        assert_eq!(view.state.selected_profile_id, Some(profile_b));
+
+        view.handle_key_down(&settings_key_event("e"), cx);
+
+        view.handle_key_down(&settings_key_event("shift-="), cx);
+        assert_eq!(
+            crate::ui_gpui::navigation_channel().take_pending(),
+            Some(ViewId::ProfileEditor)
+        );
+
+        view.handle_key_down(&settings_key_event("m"), cx);
+        assert_eq!(
+            crate::ui_gpui::navigation_channel().take_pending(),
+            Some(ViewId::McpAdd)
+        );
+
+        view.state.available_themes = vec![
+            ThemeOption {
+                name: "Green Screen".to_string(),
+                slug: "green-screen".to_string(),
+            },
+            ThemeOption {
+                name: "Midnight Nebula".to_string(),
+                slug: "default".to_string(),
+            },
+        ];
+        view.state.selected_theme_slug = "green-screen".to_string();
+        view.handle_key_down(&settings_key_event("down"), cx);
+        assert_eq!(view.state.selected_theme_slug, "default");
+        view.handle_key_down(&settings_key_event("enter"), cx);
+
+        view.handle_key_down(&settings_key_event("cmd-w"), cx);
+        assert_eq!(
+            crate::ui_gpui::navigation_channel().take_pending(),
+            Some(ViewId::Chat)
+        );
+    });
+
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::SelectProfile { id: profile_a }
+    );
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::SelectProfile { id: profile_b }
+    );
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::EditProfile { id: profile_b }
+    );
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::SelectProfile { id: profile_b }
+    );
+    assert_eq!(
+        user_rx.recv().unwrap(),
+        UserEvent::SelectTheme {
+            slug: "default".to_string()
+        }
+    );
+    assert!(
+        user_rx.try_recv().is_err(),
+        "unexpected additional settings events"
+    );
+}
+
+#[gpui::test]
+async fn static_navigation_helpers_route_to_expected_views(_cx: &mut TestAppContext) {
+    clear_navigation_requests();
+
+    SettingsView::navigate_to_profile_editor();
+    assert_eq!(
+        crate::ui_gpui::navigation_channel().take_pending(),
+        Some(ViewId::ProfileEditor)
+    );
+
+    SettingsView::navigate_to_mcp_add();
+    assert_eq!(
+        crate::ui_gpui::navigation_channel().take_pending(),
+        Some(ViewId::McpAdd)
+    );
+
+    SettingsView::navigate_to_chat();
+    assert_eq!(
+        crate::ui_gpui::navigation_channel().take_pending(),
+        Some(ViewId::Chat)
+    );
+}
+
+#[gpui::test]
+async fn tool_approval_policy_updated_applies_all_fields(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, cx| {
+        view.handle_command(
+            ViewCommand::ToolApprovalPolicyUpdated {
+                yolo_mode: true,
+                auto_approve_reads: true,
+                mcp_approval_mode: crate::agent::McpApprovalMode::PerServer,
+                persistent_allowlist: vec!["git".to_string(), "ls".to_string()],
+                persistent_denylist: vec!["rm".to_string()],
+            },
+            cx,
+        );
+    });
+
+    view.read_with(cx, |view, _cx| {
+        let state = view.get_state();
+        assert!(state.yolo_mode);
+        assert!(state.auto_approve_reads);
+        assert_eq!(
+            state.mcp_approval_mode,
+            crate::agent::McpApprovalMode::PerServer
+        );
+        assert_eq!(state.persistent_allowlist, vec!["git", "ls"]);
+        assert_eq!(state.persistent_denylist, vec!["rm"]);
+    });
+}
+
+#[gpui::test]
+async fn tool_approval_policy_updated_clears_input_buffers(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        view.state.allowlist_input = "pending-entry".to_string();
+        view.state.denylist_input = "another-pending".to_string();
+    });
+
+    view.update(cx, |view, cx| {
+        view.handle_command(
+            ViewCommand::ToolApprovalPolicyUpdated {
+                yolo_mode: false,
+                auto_approve_reads: false,
+                mcp_approval_mode: crate::agent::McpApprovalMode::PerTool,
+                persistent_allowlist: vec![],
+                persistent_denylist: vec![],
+            },
+            cx,
+        );
+    });
+
+    view.read_with(cx, |view, _cx| {
+        assert!(view.state.allowlist_input.is_empty());
+        assert!(view.state.denylist_input.is_empty());
+    });
+}
+
+#[gpui::test]
+async fn yolo_mode_changed_updates_state(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.read_with(cx, |view, _cx| {
+        assert!(!view.get_state().yolo_mode);
+    });
+
+    view.update(cx, |view, cx| {
+        view.handle_command(ViewCommand::YoloModeChanged { active: true }, cx);
+    });
+
+    view.read_with(cx, |view, _cx| {
+        assert!(view.get_state().yolo_mode);
+    });
+}
+
+#[gpui::test]
+async fn show_error_sets_status_message_as_error(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, cx| {
+        view.handle_command(
+            ViewCommand::ShowError {
+                title: "Tool Approval Settings".to_string(),
+                message: "Failed to persist allowlist".to_string(),
+                severity: crate::presentation::view_command::ErrorSeverity::Warning,
+            },
+            cx,
+        );
+    });
+
+    view.read_with(cx, |view, _cx| {
+        assert!(view.state.status_is_error);
+        assert!(view
+            .state
+            .status_message
+            .as_ref()
+            .unwrap()
+            .contains("Failed to persist allowlist"));
+    });
+}
+
+#[gpui::test]
+async fn show_notification_sets_status_without_error(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, cx| {
+        view.handle_command(
+            ViewCommand::ShowNotification {
+                message: "Settings saved".to_string(),
+            },
+            cx,
+        );
+    });
+
+    view.read_with(cx, |view, _cx| {
+        assert!(!view.state.status_is_error);
+        assert_eq!(view.state.status_message.as_deref(), Some("Settings saved"));
+    });
+}
+
+#[gpui::test]
+async fn add_allowlist_entry_emits_event_without_clearing_input(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, _cx| {
+        view.state.allowlist_input = "git".to_string();
+        view.add_allowlist_entry();
+    });
+
+    let event = user_rx.try_recv().unwrap();
+    assert_eq!(
+        event,
+        UserEvent::AddToolApprovalAllowlistPrefix {
+            prefix: "git".to_string()
+        }
+    );
+
+    view.read_with(cx, |view, _cx| {
+        assert_eq!(view.state.allowlist_input, "git");
+    });
+}
+
+#[gpui::test]
+async fn add_denylist_entry_emits_event_without_clearing_input(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, _cx| {
+        view.state.denylist_input = "rm".to_string();
+        view.add_denylist_entry();
+    });
+
+    let event = user_rx.try_recv().unwrap();
+    assert_eq!(
+        event,
+        UserEvent::AddToolApprovalDenylistPrefix {
+            prefix: "rm".to_string()
+        }
+    );
+
+    view.read_with(cx, |view, _cx| {
+        assert_eq!(view.state.denylist_input, "rm");
+    });
+}
+
+#[gpui::test]
+async fn add_entry_ignores_empty_input(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, _cx| {
+        view.state.allowlist_input = "   ".to_string();
+        view.add_allowlist_entry();
+        view.state.denylist_input = String::new();
+        view.add_denylist_entry();
+    });
+
+    assert!(user_rx.try_recv().is_err());
+}
+
+#[gpui::test]
+async fn remove_allowlist_entry_emits_event(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, _cx| {
+        view.remove_allowlist_entry("git".to_string());
+    });
+
+    assert_eq!(
+        user_rx.try_recv().unwrap(),
+        UserEvent::RemoveToolApprovalAllowlistPrefix {
+            prefix: "git".to_string()
+        }
+    );
+}
+
+#[gpui::test]
+async fn remove_denylist_entry_emits_event(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, _cx| {
+        view.remove_denylist_entry("rm".to_string());
+    });
+
+    assert_eq!(
+        user_rx.try_recv().unwrap(),
+        UserEvent::RemoveToolApprovalDenylistPrefix {
+            prefix: "rm".to_string()
+        }
+    );
+}
+
+#[gpui::test]
+async fn cycle_active_field_rotates_through_fields(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        assert!(view.state.active_field.is_none());
+
+        view.cycle_active_field();
+        assert_eq!(view.state.active_field, Some(ActiveField::AllowlistInput));
+
+        view.cycle_active_field();
+        assert_eq!(view.state.active_field, Some(ActiveField::DenylistInput));
+
+        view.cycle_active_field();
+        assert_eq!(view.state.active_field, Some(ActiveField::AllowlistInput));
+    });
+}
+
+#[gpui::test]
+async fn set_active_field_resets_ime_marked_bytes(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        view.ime_marked_byte_count = 5;
+        view.set_active_field(Some(ActiveField::DenylistInput));
+        assert_eq!(view.ime_marked_byte_count, 0);
+        assert_eq!(view.state.active_field, Some(ActiveField::DenylistInput));
+    });
+}
+
+#[gpui::test]
+async fn emit_set_yolo_mode_sends_event(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, _cx| {
+        view.emit_set_yolo_mode(true);
+    });
+
+    assert_eq!(
+        user_rx.try_recv().unwrap(),
+        UserEvent::SetToolApprovalYoloMode { enabled: true }
+    );
+}
+
+#[gpui::test]
+async fn emit_set_auto_approve_reads_sends_event(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, _cx| {
+        view.emit_set_auto_approve_reads(true);
+    });
+
+    assert_eq!(
+        user_rx.try_recv().unwrap(),
+        UserEvent::SetToolApprovalAutoApproveReads { enabled: true }
+    );
+}
+
+#[gpui::test]
+async fn emit_set_mcp_approval_mode_sends_event(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, _cx| {
+        view.emit_set_mcp_approval_mode(crate::agent::McpApprovalMode::PerServer);
+    });
+
+    assert_eq!(
+        user_rx.try_recv().unwrap(),
+        UserEvent::SetToolApprovalMcpApprovalMode {
+            mode: crate::agent::McpApprovalMode::PerServer
+        }
+    );
+}
+
+#[gpui::test]
+async fn append_to_active_field_adds_text_to_correct_buffer(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        view.set_active_field(Some(ActiveField::AllowlistInput));
+        view.append_to_active_field("hello");
+        assert_eq!(view.state.allowlist_input, "hello");
+        assert!(view.state.denylist_input.is_empty());
+
+        view.set_active_field(Some(ActiveField::DenylistInput));
+        view.append_to_active_field("world");
+        assert_eq!(view.state.denylist_input, "world");
+        assert_eq!(view.state.allowlist_input, "hello");
+    });
+}
+
+#[gpui::test]
+async fn backspace_active_field_removes_last_char(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        view.set_active_field(Some(ActiveField::AllowlistInput));
+        view.state.allowlist_input = "abc".to_string();
+        view.backspace_active_field();
+        assert_eq!(view.state.allowlist_input, "ab");
+    });
+}
+
+#[gpui::test]
+async fn active_field_text_returns_correct_buffer(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        view.state.allowlist_input = "allow".to_string();
+        view.state.denylist_input = "deny".to_string();
+
+        view.set_active_field(Some(ActiveField::AllowlistInput));
+        assert_eq!(view.active_field_text(), "allow");
+
+        view.set_active_field(Some(ActiveField::DenylistInput));
+        assert_eq!(view.active_field_text(), "deny");
+
+        view.set_active_field(None);
+        assert_eq!(view.active_field_text(), "");
+    });
+}

--- a/tests/history_and_settings_presenter_tests.rs
+++ b/tests/history_and_settings_presenter_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -270,6 +270,7 @@ struct MockAppSettingsState {
     theme: Option<String>,
     set_theme_calls: Vec<String>,
     set_theme_results: VecDeque<Result<(), ServiceError>>,
+    settings: HashMap<String, String>,
 }
 
 impl MockAppSettingsService {
@@ -282,6 +283,7 @@ impl MockAppSettingsService {
                 theme: None,
                 set_theme_calls: Vec::new(),
                 set_theme_results: VecDeque::new(),
+                settings: HashMap::new(),
             })),
         }
     }
@@ -371,11 +373,16 @@ impl AppSettingsService for MockAppSettingsService {
         result
     }
 
-    async fn get_setting(&self, _key: &str) -> Result<Option<String>, ServiceError> {
-        Ok(None)
+    async fn get_setting(&self, key: &str) -> Result<Option<String>, ServiceError> {
+        Ok(self.state.lock().unwrap().settings.get(key).cloned())
     }
 
-    async fn set_setting(&self, _key: &str, _value: String) -> Result<(), ServiceError> {
+    async fn set_setting(&self, key: &str, value: String) -> Result<(), ServiceError> {
+        self.state
+            .lock()
+            .unwrap()
+            .settings
+            .insert(key.to_string(), value);
         Ok(())
     }
 
@@ -675,6 +682,13 @@ mod settings_presenter_tests {
         )
     }
 
+    /// Drain all 5 startup commands emitted by the settings presenter.
+    async fn drain_startup(rx: &mut broadcast::Receiver<ViewCommand>) {
+        for _ in 0..5 {
+            let _ = recv_broadcast_command(rx).await;
+        }
+    }
+
     #[tokio::test]
     async fn lifecycle_start_stop_and_is_running_work() {
         let profile = make_profile(Uuid::new_v4(), "default", "openai", "gpt-4");
@@ -702,7 +716,9 @@ mod settings_presenter_tests {
                 selected_profile_id: Some(profile.id),
             }
         );
-        // Drain the ShowSettingsTheme snapshot emitted on startup
+        // Drain ShowSettingsTheme + ToolApprovalPolicyUpdated + YoloModeChanged
+        let _ = recv_broadcast_command(&mut view_rx).await;
+        let _ = recv_broadcast_command(&mut view_rx).await;
         let _ = recv_broadcast_command(&mut view_rx).await;
 
         presenter
@@ -762,9 +778,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -815,9 +829,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         let id = Uuid::new_v4();
         send_settings_event(&event_tx, AppEvent::User(UserEvent::SelectProfile { id })).await;
@@ -847,9 +859,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -894,9 +904,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(&event_tx, AppEvent::User(UserEvent::EditProfile { id })).await;
 
@@ -923,9 +931,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -968,9 +974,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -1001,9 +1005,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(&event_tx, AppEvent::User(UserEvent::RefreshProfiles)).await;
 
@@ -1039,9 +1041,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         let id = Uuid::new_v4();
         send_settings_event(
@@ -1073,9 +1073,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -1214,9 +1212,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         let id = Uuid::new_v4();
         send_settings_event(
@@ -1377,9 +1373,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -1446,6 +1440,10 @@ mod settings_presenter_tests {
         let _ = recv_broadcast_command(&mut view_rx).await;
 
         let cmd = recv_broadcast_command(&mut view_rx).await;
+        // Drain ToolApprovalPolicyUpdated + YoloModeChanged
+        let _ = recv_broadcast_command(&mut view_rx).await;
+        let _ = recv_broadcast_command(&mut view_rx).await;
+
         match cmd {
             ViewCommand::ShowSettingsTheme {
                 options,
@@ -1485,9 +1483,7 @@ mod settings_presenter_tests {
         presenter.start().await.expect("start should succeed");
 
         // Drain startup commands (ShowSettings + ChatProfilesUpdated + ShowSettingsTheme)
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -1533,9 +1529,7 @@ mod settings_presenter_tests {
 
         presenter.start().await.expect("start should succeed");
 
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -1574,10 +1568,7 @@ mod settings_presenter_tests {
             setup_settings_presenter(profile_service, app_settings_service);
 
         presenter.start().await.expect("start should succeed");
-
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         set_active_theme_slug("green-screen");
 
@@ -1625,9 +1616,7 @@ mod settings_presenter_tests {
         presenter.start().await.expect("start should succeed");
         app_settings_service.set_current_theme(Some("invalid-after-start"));
 
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(
             &event_tx,
@@ -1667,13 +1656,12 @@ mod settings_presenter_tests {
         presenter.start().await.expect("start should succeed");
 
         // Drain startup commands
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
-        let _ = recv_broadcast_command(&mut view_rx).await;
+        drain_startup(&mut view_rx).await;
 
         send_settings_event(&event_tx, AppEvent::User(UserEvent::RefreshProfiles)).await;
 
         // Should receive ShowSettings + ChatProfilesUpdated + ShowSettingsTheme
+        // + ToolApprovalPolicyUpdated + YoloModeChanged
         let first = recv_broadcast_command(&mut view_rx).await;
         assert!(
             matches!(first, ViewCommand::ShowSettings { .. }),
@@ -1689,5 +1677,187 @@ mod settings_presenter_tests {
             matches!(third, ViewCommand::ShowSettingsTheme { .. }),
             "expected ShowSettingsTheme, got {third:?}"
         );
+        let fourth = recv_broadcast_command(&mut view_rx).await;
+        assert!(
+            matches!(fourth, ViewCommand::ToolApprovalPolicyUpdated { .. }),
+            "expected ToolApprovalPolicyUpdated, got {fourth:?}"
+        );
+        let fifth = recv_broadcast_command(&mut view_rx).await;
+        assert!(
+            matches!(fifth, ViewCommand::YoloModeChanged { .. }),
+            "expected YoloModeChanged, got {fifth:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_yolo_mode_emits_policy_and_yolo_changed() {
+        let profile = make_profile(Uuid::new_v4(), "default", "openai", "gpt-4");
+        let profile_service = MockProfileService::new(vec![profile.clone()], Some(profile.id));
+        let app_settings_service = MockAppSettingsService::new(Some(profile.id));
+        let (mut presenter, event_tx, mut view_rx, _ps, _as) =
+            setup_settings_presenter(profile_service, app_settings_service);
+
+        presenter.start().await.expect("start");
+        drain_startup(&mut view_rx).await;
+
+        let _ = event_tx.send(AppEvent::User(UserEvent::SetToolApprovalYoloMode {
+            enabled: true,
+        }));
+        sleep(PROCESSING_DELAY).await;
+
+        let cmd = recv_broadcast_command(&mut view_rx).await;
+        assert!(
+            matches!(
+                cmd,
+                ViewCommand::ToolApprovalPolicyUpdated {
+                    yolo_mode: true,
+                    ..
+                }
+            ),
+            "expected ToolApprovalPolicyUpdated with yolo_mode=true, got {cmd:?}"
+        );
+
+        let cmd2 = recv_broadcast_command(&mut view_rx).await;
+        assert!(
+            matches!(cmd2, ViewCommand::YoloModeChanged { active: true }),
+            "expected YoloModeChanged active=true, got {cmd2:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_auto_approve_reads_emits_policy_update() {
+        let profile = make_profile(Uuid::new_v4(), "default", "openai", "gpt-4");
+        let profile_service = MockProfileService::new(vec![profile.clone()], Some(profile.id));
+        let app_settings_service = MockAppSettingsService::new(Some(profile.id));
+        let (mut presenter, event_tx, mut view_rx, _ps, _as) =
+            setup_settings_presenter(profile_service, app_settings_service);
+
+        presenter.start().await.expect("start");
+        drain_startup(&mut view_rx).await;
+
+        let _ = event_tx.send(AppEvent::User(UserEvent::SetToolApprovalAutoApproveReads {
+            enabled: true,
+        }));
+        sleep(PROCESSING_DELAY).await;
+
+        let cmd = recv_broadcast_command(&mut view_rx).await;
+        assert!(
+            matches!(
+                cmd,
+                ViewCommand::ToolApprovalPolicyUpdated {
+                    auto_approve_reads: true,
+                    ..
+                }
+            ),
+            "expected ToolApprovalPolicyUpdated with auto_approve_reads=true, got {cmd:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_and_remove_allowlist_prefix_roundtrips() {
+        let profile = make_profile(Uuid::new_v4(), "default", "openai", "gpt-4");
+        let profile_service = MockProfileService::new(vec![profile.clone()], Some(profile.id));
+        let app_settings_service = MockAppSettingsService::new(Some(profile.id));
+        let (mut presenter, event_tx, mut view_rx, _ps, _as) =
+            setup_settings_presenter(profile_service, app_settings_service);
+
+        presenter.start().await.expect("start");
+        drain_startup(&mut view_rx).await;
+
+        // Add "git" to allowlist
+        let _ = event_tx.send(AppEvent::User(UserEvent::AddToolApprovalAllowlistPrefix {
+            prefix: "git".to_string(),
+        }));
+        sleep(PROCESSING_DELAY).await;
+
+        let cmd = recv_broadcast_command(&mut view_rx).await;
+        match cmd {
+            ViewCommand::ToolApprovalPolicyUpdated {
+                persistent_allowlist,
+                ..
+            } => {
+                assert!(
+                    persistent_allowlist.contains(&"git".to_string()),
+                    "allowlist should contain 'git', got {persistent_allowlist:?}"
+                );
+            }
+            other => panic!("expected ToolApprovalPolicyUpdated, got {other:?}"),
+        }
+        let _ = recv_broadcast_command(&mut view_rx).await; // YoloModeChanged
+
+        // Remove "git" from allowlist
+        let _ = event_tx.send(AppEvent::User(
+            UserEvent::RemoveToolApprovalAllowlistPrefix {
+                prefix: "git".to_string(),
+            },
+        ));
+        sleep(PROCESSING_DELAY).await;
+
+        let cmd2 = recv_broadcast_command(&mut view_rx).await;
+        match cmd2 {
+            ViewCommand::ToolApprovalPolicyUpdated {
+                persistent_allowlist,
+                ..
+            } => {
+                assert!(
+                    !persistent_allowlist.contains(&"git".to_string()),
+                    "allowlist should not contain 'git' after removal, got {persistent_allowlist:?}"
+                );
+            }
+            other => panic!("expected ToolApprovalPolicyUpdated, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_and_remove_denylist_prefix_roundtrips() {
+        let profile = make_profile(Uuid::new_v4(), "default", "openai", "gpt-4");
+        let profile_service = MockProfileService::new(vec![profile.clone()], Some(profile.id));
+        let app_settings_service = MockAppSettingsService::new(Some(profile.id));
+        let (mut presenter, event_tx, mut view_rx, _ps, _as) =
+            setup_settings_presenter(profile_service, app_settings_service);
+
+        presenter.start().await.expect("start");
+        drain_startup(&mut view_rx).await;
+
+        let _ = event_tx.send(AppEvent::User(UserEvent::AddToolApprovalDenylistPrefix {
+            prefix: "rm".to_string(),
+        }));
+        sleep(PROCESSING_DELAY).await;
+
+        let cmd = recv_broadcast_command(&mut view_rx).await;
+        match cmd {
+            ViewCommand::ToolApprovalPolicyUpdated {
+                persistent_denylist,
+                ..
+            } => {
+                assert!(
+                    persistent_denylist.contains(&"rm".to_string()),
+                    "denylist should contain 'rm', got {persistent_denylist:?}"
+                );
+            }
+            other => panic!("expected ToolApprovalPolicyUpdated, got {other:?}"),
+        }
+        let _ = recv_broadcast_command(&mut view_rx).await; // YoloModeChanged
+
+        let _ = event_tx.send(AppEvent::User(
+            UserEvent::RemoveToolApprovalDenylistPrefix {
+                prefix: "rm".to_string(),
+            },
+        ));
+        sleep(PROCESSING_DELAY).await;
+
+        let cmd2 = recv_broadcast_command(&mut view_rx).await;
+        match cmd2 {
+            ViewCommand::ToolApprovalPolicyUpdated {
+                persistent_denylist,
+                ..
+            } => {
+                assert!(
+                    !persistent_denylist.contains(&"rm".to_string()),
+                    "denylist should not contain 'rm' after removal, got {persistent_denylist:?}"
+                );
+            }
+            other => panic!("expected ToolApprovalPolicyUpdated, got {other:?}"),
+        }
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -162,6 +162,7 @@ fn coverage_ignore_regex() -> String {
         // GPUI declarative render + IME impls (require live GPUI window context)
         r"/render\.rs$",
         r"/render_bars\.rs$",
+        r"/render_tool_approval\.rs$",
         r"/ime\.rs$",
     ]
     .join("|")


### PR DESCRIPTION
## Summary

Wire YOLO mode, auto-approve reads, MCP approval mode (Per Tool / Per Server), and persistent allowlist/denylist management through the full GPUI stack.

## Changes

### Domain (tool_approval_policy.rs)
- Add \`deny_persistently\`, \`remove_persistent_allow_prefix\`, \`remove_persistent_deny_prefix\` methods
- 3 new async round-trip tests

### Events (types.rs)
- 8 new \`UserEvent\` variants: \`RefreshToolApprovalPolicy\`, \`SetToolApprovalYoloMode\`, \`SetToolApprovalAutoApproveReads\`, \`SetToolApprovalMcpApprovalMode\`, \`Add/RemoveToolApprovalAllowlistPrefix\`, \`Add/RemoveToolApprovalDenylistPrefix\`

### Presenter (settings_presenter.rs)
- \`emit_tool_approval_policy_snapshot()\` emits canonical state to views
- 7 event handlers with load-modify-save-emit pattern
- Startup and \`RefreshProfiles\` emit policy snapshot
- \`ShowError\` on persistence failures

### ViewCommands (view_command.rs)
- \`ToolApprovalPolicyUpdated\` with full policy fields
- \`RefreshToolApprovalSettings\`

### SettingsView (mod.rs, command.rs, render.rs)
- \`ActiveField\` enum for allowlist/denylist text inputs
- 10 new state fields, field manipulation helpers, emit helpers
- Full \`EntityInputHandler\` impl for IME/diacritics support
- Command handler for \`ToolApprovalPolicyUpdated\`, \`YoloModeChanged\`, \`ShowError\`/\`ShowNotification\`
- Rendered UI: YOLO toggle with warning, auto-approve-reads toggle, MCP mode selector (Per Tool/Per Server), scrollable allowlist/denylist with add/remove, status bar
- IME canvas registration in render path

### ChatView (render_bars.rs)
- YOLO button now emits \`SetToolApprovalYoloMode\` instead of toggling local state directly

### MainPanel (startup.rs, command.rs, routing.rs)
- Startup emits \`RefreshToolApprovalPolicy\`
- Routes \`ToolApprovalPolicyUpdated\` to settings view
- Routes \`YoloModeChanged\` to both settings and chat views
- Routing counters for test coverage

### Tests
- 4 new MainPanel GPUI tests (routing + forwarding)
- Updated 18 presenter integration tests for new startup command sequence
- \`drain_startup\` helper for cleaner test setup

## Verification
- \`cargo fmt --all -- --check\` - clean
- \`cargo clippy --all-targets -- -D warnings\` - clean
- \`cargo test --lib --tests\` - 241 lib + all integration tests pass

Fixes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool approval settings UI: YOLO toggle, auto-approve reads, MCP approval mode selector, editable persistent allow/deny lists with add/remove controls, status banners, and scrollable lists.
  * Live sync and persistence: settings emit/receive policy snapshots at startup and on changes so UI and stored preferences stay in sync.
  * Improved input: keyboard/IME support for editing allow/deny inputs and focused active-field behavior.

* **Tests**
  * Expanded tests for persistence, add/remove roundtrips, command routing/forwarding, UI state updates, and view integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->