### PR TITLE
Fix hardcoded colors to respect active theme palette (Fixes #60)

### DIFF
--- a/src/ui_gpui/components/toggle.rs
+++ b/src/ui_gpui/components/toggle.rs
@@ -71,7 +71,7 @@ impl IntoElement for Toggle {
                     .w(px(20.0))
                     .h(px(20.0))
                     .rounded(px(10.0))
-                    .bg(gpui::white()),
+                    .bg(Theme::selection_fg()),
             )
     }
 }

--- a/src/ui_gpui/views/api_key_manager_view/render.rs
+++ b/src/ui_gpui/views/api_key_manager_view/render.rs
@@ -143,7 +143,7 @@ impl ApiKeyManagerView {
                     .py(px(2.0))
                     .rounded(px(4.0))
                     .text_size(px(11.0))
-                    .text_color(gpui::rgb(0x00EF_4444))
+                    .text_color(Theme::error())
                     .hover(|s| s.bg(Theme::bg_dark()))
                     .child("Delete")
                     .on_mouse_down(
@@ -323,7 +323,7 @@ impl ApiKeyManagerView {
                                         d.bg(Theme::accent()).child(
                                             div()
                                                 .text_size(px(8.0))
-                                                .text_color(gpui::white())
+                                                .text_color(Theme::selection_fg())
                                                 .child("v"),
                                         )
                                     }),
@@ -461,7 +461,7 @@ impl ApiKeyManagerView {
                 d.child(
                     div()
                         .text_size(px(11.0))
-                        .text_color(gpui::rgb(0x00EF_4444))
+                        .text_color(Theme::error())
                         .child(self.state.error.clone().unwrap_or_default()),
                 )
             })

--- a/src/ui_gpui/views/chat_view/render.rs
+++ b/src/ui_gpui/views/chat_view/render.rs
@@ -594,7 +594,7 @@ impl ChatView {
             .cursor_pointer()
             .when(is_streaming, |d| {
                 d.bg(Theme::error())
-                    .text_color(gpui::white())
+                    .text_color(Theme::selection_fg())
                     .child("Stop")
                     .on_mouse_down(
                         MouseButton::Left,

--- a/src/ui_gpui/views/chat_view/render_bars.rs
+++ b/src/ui_gpui/views/chat_view/render_bars.rs
@@ -165,8 +165,8 @@ impl ChatView {
                     .justify_center()
                     .cursor_pointer()
                     .bg(Theme::bg_darker())
-                    .hover(|s| s.bg(gpui::rgb(0x008B_0000)))
-                    .active(|s| s.bg(gpui::rgb(0x005C_0000)))
+                    .hover(|s| s.bg(Theme::danger()))
+                    .active(|s| s.bg(Theme::danger()))
                     .text_size(px(14.0))
                     .text_color(Theme::text_primary())
                     .child("\u{23FB}")
@@ -608,10 +608,11 @@ impl ChatView {
             .py(px(6.0))
             .cursor_pointer()
             .when(selected, |row| {
-                row.bg(Theme::accent()).text_color(gpui::white())
+                row.bg(Theme::accent()).text_color(Theme::selection_fg())
             })
             .when(!selected && highlighted, |row| {
-                row.bg(Theme::accent_hover()).text_color(gpui::white())
+                row.bg(Theme::accent_hover())
+                    .text_color(Theme::selection_fg())
             })
             .when(!selected && !highlighted, |row| {
                 row.hover(|s| s.bg(Theme::bg_darker()))
@@ -724,10 +725,11 @@ impl ChatView {
             .py(px(6.0))
             .cursor_pointer()
             .when(is_selected, |row| {
-                row.bg(Theme::accent()).text_color(gpui::white())
+                row.bg(Theme::accent()).text_color(Theme::selection_fg())
             })
             .when(!is_selected && is_highlighted, |row| {
-                row.bg(Theme::accent_hover()).text_color(gpui::white())
+                row.bg(Theme::accent_hover())
+                    .text_color(Theme::selection_fg())
             })
             .when(!is_selected && !is_highlighted, |row| {
                 row.hover(|s| s.bg(Theme::bg_darker()))

--- a/src/ui_gpui/views/mcp_add_view/render.rs
+++ b/src/ui_gpui/views/mcp_add_view/render.rs
@@ -69,7 +69,7 @@ impl McpAddView {
                         d.cursor_pointer()
                             .bg(Theme::accent())
                             .hover(|s| s.bg(Theme::accent_hover()))
-                            .text_color(gpui::white())
+                            .text_color(Theme::selection_fg())
                             .on_mouse_down(
                                 MouseButton::Left,
                                 cx.listener(|this, _, _window, _cx| {
@@ -373,7 +373,7 @@ impl McpAddView {
                             .text_size(px(12.0))
                             .font_weight(FontWeight::BOLD)
                             .text_color(if is_selected {
-                                gpui::white()
+                                Theme::selection_fg()
                             } else {
                                 Theme::text_primary()
                             })

--- a/src/ui_gpui/views/mcp_configure_view/render.rs
+++ b/src/ui_gpui/views/mcp_configure_view/render.rs
@@ -67,7 +67,7 @@ impl McpConfigureView {
                         d.cursor_pointer()
                             .bg(Theme::accent())
                             .hover(|s| s.bg(Theme::accent_hover()))
-                            .text_color(gpui::white())
+                            .text_color(Theme::selection_fg())
                             .on_mouse_down(
                                 MouseButton::Left,
                                 cx.listener(|this, _, _window, _cx| {
@@ -254,7 +254,7 @@ impl McpConfigureView {
                                         d.bg(Theme::accent()).child(
                                             div()
                                                 .text_size(px(8.0))
-                                                .text_color(gpui::white())
+                                                .text_color(Theme::selection_fg())
                                                 .child("v"),
                                         )
                                     }),
@@ -390,7 +390,7 @@ impl McpConfigureView {
                     .cursor_pointer()
                     .hover(|s| s.bg(Theme::accent_hover()))
                     .text_size(px(12.0))
-                    .text_color(gpui::white())
+                    .text_color(Theme::selection_fg())
                     .child(format!("Authorize with {provider}"))
                     .on_mouse_down(
                         MouseButton::Left,
@@ -485,7 +485,7 @@ impl McpConfigureView {
                         d.bg(Theme::accent()).child(
                             div()
                                 .text_size(px(10.0))
-                                .text_color(gpui::white())
+                                .text_color(Theme::selection_fg())
                                 .child("v"),
                         )
                     }),

--- a/src/ui_gpui/views/model_selector_view/render.rs
+++ b/src/ui_gpui/views/model_selector_view/render.rs
@@ -197,7 +197,7 @@ impl ModelSelectorView {
                                 d.bg(Theme::accent()).child(
                                     div()
                                         .text_size(px(10.0))
-                                        .text_color(gpui::white())
+                                        .text_color(Theme::selection_fg())
                                         .child("[OK]"),
                                 )
                             }),
@@ -236,7 +236,7 @@ impl ModelSelectorView {
                                 d.bg(Theme::accent()).child(
                                     div()
                                         .text_size(px(10.0))
-                                        .text_color(gpui::white())
+                                        .text_color(Theme::selection_fg())
                                         .child("[OK]"),
                                 )
                             }),

--- a/src/ui_gpui/views/profile_editor_view/render.rs
+++ b/src/ui_gpui/views/profile_editor_view/render.rs
@@ -74,7 +74,7 @@ impl ProfileEditorView {
                         d.cursor_pointer()
                             .bg(Theme::accent())
                             .hover(|s| s.bg(Theme::accent_hover()))
-                            .text_color(gpui::white())
+                            .text_color(Theme::selection_fg())
                             .on_mouse_down(
                                 MouseButton::Left,
                                 cx.listener(|this, _, _window, _cx| {
@@ -599,7 +599,7 @@ impl ProfileEditorView {
                         d.bg(Theme::accent()).child(
                             div()
                                 .text_size(px(10.0))
-                                .text_color(gpui::white())
+                                .text_color(Theme::selection_fg())
                                 .child("v"),
                         )
                     }),
@@ -650,7 +650,7 @@ impl ProfileEditorView {
                                 d.bg(Theme::accent()).child(
                                     div()
                                         .text_size(px(10.0))
-                                        .text_color(gpui::white())
+                                        .text_color(Theme::selection_fg())
                                         .child("v"),
                                 )
                             }),

--- a/src/ui_gpui/views/settings_view/render_tool_approval.rs
+++ b/src/ui_gpui/views/settings_view/render_tool_approval.rs
@@ -40,7 +40,7 @@ impl SettingsView {
                         d.bg(Theme::accent()).child(
                             div()
                                 .text_size(px(9.0))
-                                .text_color(gpui::white())
+                                .text_color(Theme::selection_fg())
                                 .child("v"),
                         )
                     }),
@@ -396,7 +396,7 @@ impl SettingsView {
                         })
                         .text_size(px(11.0))
                         .text_color(if self.state.status_is_error {
-                            gpui::white()
+                            Theme::selection_fg()
                         } else {
                             Theme::text_primary()
                         })


### PR DESCRIPTION
## Description

This PR fixes 20 hardcoded color violations across 10 files in the GPUI UI layer. Dropdowns, buttons, checkboxes, and other controls were using hardcoded white text on accent backgrounds, which rendered invisibly on themes like Greenscreen where selection foreground is black.

## Changes

### Category 1: gpui::white() replaced with Theme::selection_fg() (16 instances)
All text/checkmarks on accent/selection backgrounds now use the theme-driven selection_fg() token:

- chat_view/render_bars.rs: Conversation dropdown and Profile dropdown selected/highlighted rows
- chat_view/render.rs: Stop button text on error background
- components/toggle.rs: Toggle knob circle
- api_key_manager_view/render.rs: Mask checkbox checkmark
- model_selector_view/render.rs: Reasoning and Vision filter checkboxes
- mcp_configure_view/render.rs: Save button, Mask checkbox, OAuth button, Boolean config checkbox
- mcp_add_view/render.rs: Next button, Selected item text
- profile_editor_view/render.rs: Save button, Show Thinking checkbox, Extended Thinking checkbox
- settings_view/render_tool_approval.rs: Tool approval checkbox, Error status bar text

### Category 2: Hardcoded gpui::rgb() replaced with theme tokens (4 instances)
- api_key_manager_view/render.rs: Delete button text and Error message text now use Theme::error()
- chat_view/render_bars.rs: Exit button hover and active states now both use Theme::danger()

## Verification

- cargo fmt --all: clean
- cargo clippy --all-targets -- -D warnings: clean
- cargo test --lib --tests: 376 passed

## Fixes

Fixes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI component colors throughout the application to derive from the app's theme instead of hardcoded values, including buttons, toggles, checkboxes, and text indicators. This ensures a more consistent visual appearance across all interface elements and improved theme alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->