### PR TITLE
Add template variable expansion to system prompts (Fixes #67)

### DIFF
--- a/src/llm/stream.rs
+++ b/src/llm/stream.rs
@@ -4,6 +4,7 @@ use super::client::LlmClient;
 use super::error::{LlmError, LlmResult};
 use super::events::ChatStreamEvent;
 use crate::models::{AuthConfig, Conversation, MessageRole};
+use crate::services::template::{expand_system_prompt, TemplateContext};
 use futures::stream::{Stream, StreamExt};
 use serdes_ai::agent::{AgentBuilder, AgentStreamEvent, ModelConfig, RunOptions};
 use serdes_ai::core::messages::{ModelRequest, ModelRequestPart, ModelResponse, UserPromptPart};
@@ -75,11 +76,17 @@ pub async fn send_message_stream(
     let config = ModelConfig::new(&model_spec).with_api_key(&api_key);
 
     // Build system prompt from conversation if there's a system message
-    let system_prompt = conversation
+    let raw_system_prompt = conversation
         .messages
         .iter()
         .find(|m| m.role == MessageRole::System)
         .map(|m| m.content.clone());
+
+    // Create template context and expand system prompt
+    let template_ctx =
+        TemplateContext::new(conversation.created_at, &profile.name, &profile.model_id);
+    let system_prompt =
+        raw_system_prompt.map(|prompt| expand_system_prompt(&prompt, &template_ctx));
 
     // Create the agent using our new from_config method
     let mut builder: AgentBuilder<(), String> = AgentBuilder::from_config(config)

--- a/src/services/chat_impl.rs
+++ b/src/services/chat_impl.rs
@@ -9,6 +9,7 @@ use crate::llm::AgentClientExt;
 use crate::llm::{LlmClient, Message as LlmMessage, StreamEvent as LlmStreamEvent};
 use crate::mcp::McpService;
 use crate::models::MessageRole;
+use crate::services::template::{expand_system_prompt, TemplateContext};
 use crate::services::ConversationService;
 use futures::{stream, Stream};
 use std::pin::Pin;
@@ -83,8 +84,13 @@ impl ChatServiceImpl {
         let client = LlmClient::from_profile(&profile)
             .map_err(|e| ServiceError::Internal(format!("Failed to create LLM client: {e}")))?;
         let messages = Self::build_llm_messages(&conversation, &profile);
-        let system_prompt =
+        let raw_system_prompt =
             Self::system_prompt_for_conversation(&conversation, &profile).to_string();
+
+        // Expand template variables in the system prompt
+        let template_ctx =
+            TemplateContext::new(conversation.created_at, &profile.name, &profile.model_id);
+        let system_prompt = expand_system_prompt(&raw_system_prompt, &template_ctx);
 
         Ok(PreparedMessageContext {
             profile,
@@ -109,6 +115,10 @@ impl ChatServiceImpl {
         conversation: &crate::models::Conversation,
         profile: &crate::models::ModelProfile,
     ) -> Vec<LlmMessage> {
+        // Create template context for expanding system messages
+        let template_ctx =
+            TemplateContext::new(conversation.created_at, &profile.name, &profile.model_id);
+
         let has_system_message = conversation
             .messages
             .iter()
@@ -118,14 +128,20 @@ impl ChatServiceImpl {
             .messages
             .iter()
             .map(|msg| match msg.role {
-                MessageRole::System => LlmMessage::system(msg.content.clone()),
+                MessageRole::System => {
+                    // Expand template variables in conversation system messages
+                    let expanded = expand_system_prompt(&msg.content, &template_ctx);
+                    LlmMessage::system(expanded)
+                }
                 MessageRole::User => LlmMessage::user(msg.content.clone()),
                 MessageRole::Assistant => LlmMessage::assistant(msg.content.clone()),
             })
             .collect();
 
         if !has_system_message && !profile.system_prompt.trim().is_empty() {
-            messages.insert(0, LlmMessage::system(profile.system_prompt.clone()));
+            // Expand template variables in the profile system prompt fallback
+            let expanded = expand_system_prompt(&profile.system_prompt, &template_ctx);
+            messages.insert(0, LlmMessage::system(expanded));
         }
 
         messages

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -31,6 +31,7 @@ pub mod profile_migration;
 pub mod secrets;
 pub mod secrets_impl;
 pub mod secure_store;
+pub mod template;
 
 use thiserror::Error;
 
@@ -80,6 +81,7 @@ pub use mcp_registry::McpRegistryService;
 pub use models_registry::ModelsRegistryService;
 pub use profile::ProfileService;
 pub use secrets::SecretsService;
+pub use template::{expand_system_prompt, TemplateContext};
 
 // Re-export service implementations
 pub use app_settings_impl::AppSettingsServiceImpl;

--- a/src/services/template.rs
+++ b/src/services/template.rs
@@ -1,0 +1,214 @@
+//! Template variable expansion for system prompts
+//!
+//! This module provides simple template expansion for system prompts, allowing
+//! users to include dynamic variables like session date, profile name, etc.
+//!
+//! Template variables:
+//! - `{{session_date}}` - `conversation.created_at` formatted as %Y-%m-%d
+//! - `{{session_datetime}}` - `conversation.created_at` formatted as %Y-%m-%dT%H:%M:%SZ
+//! - `{{day_of_week}}` - `conversation.created_at` weekday name
+//! - `{{profile_name}}` - `profile.name`
+//! - `{{model_id}}` - `profile.model_id`
+//! - `{{os}}` - `std::env::consts::OS`
+
+use chrono::DateTime;
+use chrono::Utc;
+
+/// Context for template expansion, sourced from immutable conversation data
+/// to ensure determinism for KV cache compatibility.
+pub struct TemplateContext<'a> {
+    /// Conversation creation timestamp (immutable once created)
+    pub created_at: DateTime<Utc>,
+    /// Profile name
+    pub profile_name: &'a str,
+    /// Model ID
+    pub model_id: &'a str,
+}
+
+impl<'a> TemplateContext<'a> {
+    /// Create a new `TemplateContext` from conversation and profile data
+    #[must_use]
+    pub const fn new(created_at: DateTime<Utc>, profile_name: &'a str, model_id: &'a str) -> Self {
+        Self {
+            created_at,
+            profile_name,
+            model_id,
+        }
+    }
+}
+
+/// Expand template variables in a system prompt string.
+///
+/// Unknown/misspelled variables pass through as literal text — no error,
+/// no silent swallowing. The user sees them in LLM output and can spot the mistake.
+///
+/// # Arguments
+///
+/// * `template` - The template string with optional {{variable}} placeholders
+/// * `ctx` - `TemplateContext` containing the variable values
+///
+/// # Returns
+///
+/// The expanded string with all known template variables replaced.
+#[must_use]
+pub fn expand_system_prompt(template: &str, ctx: &TemplateContext<'_>) -> String {
+    let mut result = template.to_string();
+
+    // session_date: %Y-%m-%d
+    result = result.replace(
+        "{{session_date}}",
+        &ctx.created_at.format("%Y-%m-%d").to_string(),
+    );
+
+    // session_datetime: %Y-%m-%dT%H:%M:%SZ
+    result = result.replace(
+        "{{session_datetime}}",
+        &ctx.created_at.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+    );
+
+    // day_of_week: full weekday name
+    result = result.replace("{{day_of_week}}", &ctx.created_at.format("%A").to_string());
+
+    // profile_name
+    result = result.replace("{{profile_name}}", ctx.profile_name);
+
+    // model_id
+    result = result.replace("{{model_id}}", ctx.model_id);
+
+    // os: std::env::consts::OS
+    result = result.replace("{{os}}", std::env::consts::OS);
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_context() -> TemplateContext<'static> {
+        // Use a fixed timestamp for deterministic tests: 2026-03-30 11:26:48 UTC (Monday)
+        let created_at = DateTime::parse_from_rfc3339("2026-03-30T11:26:48Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        TemplateContext {
+            created_at,
+            profile_name: "My Claude Profile",
+            model_id: "claude-sonnet-4-20250514",
+        }
+    }
+
+    #[test]
+    fn test_session_date_expansion() {
+        let ctx = fixed_context();
+        let result = expand_system_prompt("Today is {{session_date}}.", &ctx);
+        assert_eq!(result, "Today is 2026-03-30.");
+    }
+
+    #[test]
+    fn test_session_datetime_expansion() {
+        let ctx = fixed_context();
+        let result = expand_system_prompt("Timestamp: {{session_datetime}}", &ctx);
+        assert_eq!(result, "Timestamp: 2026-03-30T11:26:48Z");
+    }
+
+    #[test]
+    fn test_day_of_week_expansion() {
+        let ctx = fixed_context();
+        let result = expand_system_prompt("It is {{day_of_week}}.", &ctx);
+        assert_eq!(result, "It is Monday.");
+    }
+
+    #[test]
+    fn test_profile_name_expansion() {
+        let ctx = fixed_context();
+        let result = expand_system_prompt("Profile: {{profile_name}}", &ctx);
+        assert_eq!(result, "Profile: My Claude Profile");
+    }
+
+    #[test]
+    fn test_model_id_expansion() {
+        let ctx = fixed_context();
+        let result = expand_system_prompt("Model: {{model_id}}", &ctx);
+        assert_eq!(result, "Model: claude-sonnet-4-20250514");
+    }
+
+    #[test]
+    fn test_os_expansion() {
+        let ctx = fixed_context();
+        let result = expand_system_prompt("OS: {{os}}", &ctx);
+        // Result depends on the platform we're running on
+        let expected_os = std::env::consts::OS;
+        assert_eq!(result, format!("OS: {expected_os}"));
+    }
+
+    #[test]
+    fn test_all_variables_combined() {
+        let ctx = fixed_context();
+        let template = "You are {{profile_name}} using {{model_id}} on {{os}}. Today is {{session_date}} ({{day_of_week}}) at {{session_datetime}}.";
+        let result = expand_system_prompt(template, &ctx);
+        let expected_os = std::env::consts::OS;
+        assert_eq!(
+            result,
+            format!("You are My Claude Profile using claude-sonnet-4-20250514 on {expected_os}. Today is 2026-03-30 (Monday) at 2026-03-30T11:26:48Z.")
+        );
+    }
+
+    #[test]
+    fn test_no_op_on_plain_text() {
+        let ctx = fixed_context();
+        let template = "You are a helpful assistant.";
+        let result = expand_system_prompt(template, &ctx);
+        assert_eq!(result, "You are a helpful assistant.");
+    }
+
+    #[test]
+    fn test_unknown_variables_pass_through() {
+        let ctx = fixed_context();
+        let template = "Hello {{typo}} and {{unknown_var}}!";
+        let result = expand_system_prompt(template, &ctx);
+        // Unknown variables pass through unchanged
+        assert_eq!(result, "Hello {{typo}} and {{unknown_var}}!");
+    }
+
+    #[test]
+    fn test_mixed_known_and_unknown_variables() {
+        let ctx = fixed_context();
+        let template = "Date: {{session_date}}, Unknown: {{not_a_var}}, Model: {{model_id}}";
+        let result = expand_system_prompt(template, &ctx);
+        assert_eq!(
+            result,
+            "Date: 2026-03-30, Unknown: {{not_a_var}}, Model: claude-sonnet-4-20250514"
+        );
+    }
+
+    #[test]
+    fn test_determinism_same_input_same_output() {
+        let ctx = fixed_context();
+        let template =
+            "{{session_date}} {{session_datetime}} {{day_of_week}} {{profile_name}} {{model_id}}";
+
+        let result1 = expand_system_prompt(template, &ctx);
+        let result2 = expand_system_prompt(template, &ctx);
+        let result3 = expand_system_prompt(template, &ctx);
+
+        // All results should be identical
+        assert_eq!(result1, result2);
+        assert_eq!(result2, result3);
+    }
+
+    #[test]
+    fn test_empty_template() {
+        let ctx = fixed_context();
+        let result = expand_system_prompt("", &ctx);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_multiple_same_variable() {
+        let ctx = fixed_context();
+        let template = "{{session_date}} and {{session_date}} again";
+        let result = expand_system_prompt(template, &ctx);
+        assert_eq!(result, "2026-03-30 and 2026-03-30 again");
+    }
+}


### PR DESCRIPTION
This PR implements template variable expansion for system prompts as described in issue #67.

## Summary
Users can now include dynamic variables in their system prompts using the {{variable}} syntax. This allows providing current date/time, profile information, and OS context to the LLM without manual editing.

## Template Variables

| Variable | Source | Example Output |
|---|---|---|
| {{session_date}} | conversation.created_at formatted %Y-%m-%d | 2026-03-30 |
| {{session_datetime}} | conversation.created_at formatted %Y-%m-%dT%H:%M:%SZ | 2026-03-30T11:26:48Z |
| {{day_of_week}} | conversation.created_at weekday | Monday |
| {{profile_name}} | profile.name | My Claude Profile |
| {{model_id}} | profile.model_id | claude-sonnet-4-20250514 |
| {{os}} | std::env::consts::OS | macos / linux / windows |

## KV Cache Constraint

All variables are deterministic for the lifetime of a conversation, sourced from conversation.created_at (immutable once created) rather than wall-clock time. This ensures byte-identical system prompts across API calls within a conversation, allowing LLM providers to reuse cached KV prefix computation.

## Implementation

- New module: src/services/template.rs (~100 LoC including tests)
- TemplateContext struct with created_at, profile_name, model_id
- expand_system_prompt() performs chained .replace() calls - no external template engine dependency
- Unknown variables pass through unchanged as literal text
- Integration in chat_impl.rs and llm/stream.rs

## Testing

- All 12 template tests pass covering each variable in isolation
- Combined template expansion tested
- Unknown variable passthrough verified
- Determinism (same input = same output) confirmed
- Plain text (no templates) no-op verified

Fixes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System prompts now support dynamic template variables that automatically expand with contextual information, including session date/time, profile name, model ID, and operating system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->