### PR TITLE
Redesign settings to category sidebar + content panel layout (Fixes #71)

### DIFF
--- a/src/ui_gpui/views/mod.rs
+++ b/src/ui_gpui/views/mod.rs
@@ -28,5 +28,5 @@ pub use profile_editor_view::{
     ApiType, AuthMethod, ProfileEditorData, ProfileEditorState, ProfileEditorView,
 };
 pub use settings_view::{
-    McpItem, McpStatus, ProfileItem, SettingsState, SettingsView, ThemeOption,
+    McpItem, McpStatus, ProfileItem, SettingsCategory, SettingsState, SettingsView, ThemeOption,
 };

--- a/src/ui_gpui/views/settings_view/mod.rs
+++ b/src/ui_gpui/views/settings_view/mod.rs
@@ -124,6 +124,30 @@ pub struct ThemeOption {
     pub slug: String,
 }
 
+/// Categories shown in the settings sidebar.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SettingsCategory {
+    #[default]
+    General,
+    Models,
+    Security,
+    McpTools,
+}
+
+impl SettingsCategory {
+    pub const ALL: [Self; 4] = [Self::General, Self::Models, Self::Security, Self::McpTools];
+
+    #[must_use]
+    pub const fn display_name(&self) -> &'static str {
+        match self {
+            Self::General => "General",
+            Self::Models => "Models",
+            Self::Security => "Security",
+            Self::McpTools => "MCP Tools",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)]
 pub(super) enum ActiveField {
@@ -134,6 +158,7 @@ pub(super) enum ActiveField {
 
 /// Settings view state
 /// @plan PLAN-20250130-GPUIREDUX.P06
+#[allow(clippy::struct_excessive_bools)]
 pub struct SettingsState {
     pub profiles: Vec<ProfileItem>,
     pub mcps: Vec<McpItem>,
@@ -143,6 +168,8 @@ pub struct SettingsState {
     pub available_themes: Vec<ThemeOption>,
     /// Slug of the currently-selected theme.
     pub selected_theme_slug: String,
+    pub selected_category: SettingsCategory,
+    pub theme_dropdown_open: bool,
     pub yolo_mode: bool,
     pub auto_approve_reads: bool,
     pub mcp_approval_mode: McpApprovalMode,
@@ -172,6 +199,8 @@ impl Default for SettingsState {
             selected_mcp_id: None,
             available_themes: Vec::new(),
             selected_theme_slug: "green-screen".to_string(),
+            selected_category: SettingsCategory::General,
+            theme_dropdown_open: false,
             yolo_mode: false,
             auto_approve_reads: false,
             mcp_approval_mode: McpApprovalMode::PerTool,
@@ -605,20 +634,35 @@ impl SettingsView {
         }
 
         if key == "up" {
-            self.scroll_profiles(-1);
-            self.scroll_themes(-1);
+            match self.state.selected_category {
+                SettingsCategory::Models => self.scroll_profiles(-1),
+                SettingsCategory::McpTools => self.scroll_mcps(-1),
+                SettingsCategory::General if self.state.theme_dropdown_open => {
+                    self.scroll_themes(-1);
+                }
+                _ => {}
+            }
             cx.notify();
             return;
         }
 
         if key == "down" {
-            self.scroll_profiles(1);
-            self.scroll_themes(1);
+            match self.state.selected_category {
+                SettingsCategory::Models => self.scroll_profiles(1),
+                SettingsCategory::McpTools => self.scroll_mcps(1),
+                SettingsCategory::General if self.state.theme_dropdown_open => {
+                    self.scroll_themes(1);
+                }
+                _ => {}
+            }
             cx.notify();
             return;
         }
 
-        if key == "space" {
+        if key == "space"
+            && self.state.selected_category == SettingsCategory::General
+            && self.state.theme_dropdown_open
+        {
             self.apply_selected_theme(cx);
         }
     }
@@ -642,7 +686,13 @@ impl SettingsView {
             }
             None => {}
         }
-        self.apply_selected_theme(cx);
+        if self.state.selected_category == SettingsCategory::General
+            && self.state.theme_dropdown_open
+        {
+            self.apply_selected_theme(cx);
+            self.state.theme_dropdown_open = false;
+            cx.notify();
+        }
     }
 
     fn save_export_directory(&self) {
@@ -694,6 +744,54 @@ impl SettingsView {
             });
         if let Some(slug) = selected_slug {
             self.select_theme(slug, cx);
+        }
+    }
+
+    pub(super) const fn select_category(&mut self, category: SettingsCategory) {
+        self.state.selected_category = category;
+        self.state.theme_dropdown_open = false;
+        self.state.active_field = None;
+        self.ime_marked_byte_count = 0;
+    }
+
+    pub(super) const fn toggle_theme_dropdown(&mut self) {
+        self.state.theme_dropdown_open = !self.state.theme_dropdown_open;
+    }
+
+    pub(super) const fn close_theme_dropdown(&mut self) {
+        self.state.theme_dropdown_open = false;
+    }
+
+    pub(super) fn select_theme_from_dropdown(
+        &mut self,
+        slug: String,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        self.select_theme(slug, cx);
+        self.state.theme_dropdown_open = false;
+    }
+
+    fn scroll_mcps(&mut self, delta_steps: i32) {
+        if self.state.mcps.is_empty() || delta_steps == 0 {
+            return;
+        }
+
+        let current = self
+            .state
+            .selected_mcp_id
+            .and_then(|id| self.state.mcps.iter().position(|m| m.id == id))
+            .unwrap_or(0);
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            clippy::cast_sign_loss
+        )]
+        let next = {
+            let max_index = self.state.mcps.len().saturating_sub(1) as i32;
+            (current as i32 + delta_steps).clamp(0, max_index) as usize
+        };
+        if let Some(mcp) = self.state.mcps.get(next) {
+            self.state.selected_mcp_id = Some(mcp.id);
         }
     }
 

--- a/src/ui_gpui/views/settings_view/render.rs
+++ b/src/ui_gpui/views/settings_view/render.rs
@@ -1,6 +1,6 @@
 //! Render implementation for `SettingsView`.
 
-use super::{McpItem, McpStatus, ProfileItem, SettingsView};
+use super::{McpItem, McpStatus, ProfileItem, SettingsCategory, SettingsView};
 use crate::events::types::UserEvent;
 use crate::ui_gpui::theme::Theme;
 use gpui::{
@@ -10,7 +10,6 @@ use gpui::{
 
 impl SettingsView {
     /// Render the top bar with back button and title
-    /// @plan PLAN-20250130-GPUIREDUX.P06
     fn render_top_bar(cx: &mut gpui::Context<Self>) -> impl IntoElement {
         div()
             .id("settings-top-bar")
@@ -22,14 +21,11 @@ impl SettingsView {
             .px(px(12.0))
             .flex()
             .items_center()
-            .justify_between()
-            // Left: back button + title
             .child(
                 div()
                     .flex()
                     .items_center()
                     .gap(px(8.0))
-                    // Back button - uses navigation_channel
                     .child(
                         div()
                             .id("btn-back")
@@ -53,33 +49,12 @@ impl SettingsView {
                                 }),
                             ),
                     )
-                    // Title
                     .child(
                         div()
                             .text_size(px(14.0))
                             .font_weight(FontWeight::BOLD)
                             .text_color(Theme::text_primary())
                             .child("Settings"),
-                    ),
-            )
-            // Right: Refresh Models button
-            .child(
-                div()
-                    .id("btn-refresh-models")
-                    .px(px(12.0))
-                    .py(px(6.0))
-                    .rounded(px(4.0))
-                    .cursor_pointer()
-                    .hover(|s| s.bg(Theme::bg_dark()))
-                    .text_size(px(12.0))
-                    .text_color(Theme::text_primary())
-                    .child("Refresh Models")
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _, _window, _cx| {
-                            tracing::info!("Refresh Models clicked");
-                            this.emit(&UserEvent::RefreshModelsRegistry);
-                        }),
                     ),
             )
     }
@@ -123,8 +98,7 @@ impl SettingsView {
             .into_any_element()
     }
 
-    /// Render the profiles section
-    /// @plan PLAN-20250130-GPUIREDUX.P06
+    /// Render the profiles list and toolbar (no header — caller provides it).
     fn render_profiles_section(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
         let profiles = &self.state.profiles;
         let total_profiles = profiles.len();
@@ -132,20 +106,13 @@ impl SettingsView {
         div()
             .flex()
             .flex_col()
+            .flex_1()
             .gap(px(6.0))
-            // Section header
-            .child(
-                div()
-                    .text_size(px(11.0))
-                    .text_color(Theme::text_primary())
-                    .child("PROFILES"),
-            )
-            // List box
             .child(
                 div()
                     .id("profiles-list")
                     .w_full()
-                    .h(px(100.0))
+                    .flex_1()
                     .bg(Theme::bg_darker())
                     .border_1()
                     .border_color(Theme::border())
@@ -174,7 +141,6 @@ impl SettingsView {
                         )
                     }),
             )
-            // Toolbar: [-] [+] [spacer] [Edit]
             .child(self.render_profiles_toolbar(cx))
     }
 
@@ -356,8 +322,7 @@ impl SettingsView {
             .into_any_element()
     }
 
-    /// Render the MCP tools section
-    /// @plan PLAN-20250130-GPUIREDUX.P06
+    /// Render the MCP tools section with full-height list.
     fn render_mcp_section(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
         let mcps = &self.state.mcps;
         let total_mcps = mcps.len();
@@ -365,20 +330,19 @@ impl SettingsView {
         div()
             .flex()
             .flex_col()
+            .flex_1()
             .gap(px(6.0))
-            // Section header
             .child(
                 div()
                     .text_size(px(11.0))
                     .text_color(Theme::text_primary())
                     .child("MCP TOOLS"),
             )
-            // List box
             .child(
                 div()
                     .id("mcps-list")
                     .w_full()
-                    .h(px(100.0))
+                    .flex_1()
                     .bg(Theme::bg_darker())
                     .border_1()
                     .border_color(Theme::border())
@@ -407,7 +371,6 @@ impl SettingsView {
                         )
                     }),
             )
-            // Toolbar: [-] [+] [spacer] [Edit]
             .child(self.render_mcp_toolbar(cx))
     }
 
@@ -501,44 +464,6 @@ impl SettingsView {
                         }),
                     ),
             )
-    }
-
-    /// Render a single row in the theme dropdown list.
-    fn render_theme_row(
-        &self,
-        option: &super::ThemeOption,
-        cx: &mut gpui::Context<Self>,
-    ) -> gpui::AnyElement {
-        let slug = option.slug.clone();
-        let name = option.name.clone();
-        let is_selected = self.state.selected_theme_slug == slug;
-
-        div()
-            .id(gpui::SharedString::from(format!("theme-{slug}")))
-            .w_full()
-            .h(px(24.0))
-            .px(px(8.0))
-            .flex()
-            .items_center()
-            .cursor_pointer()
-            .when(is_selected, |d| {
-                d.bg(Theme::selection_bg())
-                    .text_color(Theme::selection_fg())
-            })
-            .when(!is_selected, |d| {
-                d.hover(|s| s.bg(Theme::bg_dark()))
-                    .text_color(Theme::text_primary())
-            })
-            .text_size(px(12.0))
-            .child(name)
-            .on_mouse_down(
-                gpui::MouseButton::Left,
-                cx.listener(move |this, _, _window, cx| {
-                    tracing::info!("Theme selected: {}", slug);
-                    this.select_theme(slug.clone(), cx);
-                }),
-            )
-            .into_any_element()
     }
 
     /// Render the export directory setting section.
@@ -683,8 +608,76 @@ impl SettingsView {
             )
     }
 
-    /// Render the theme selection section.
-    fn render_theme_section(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+    /// Render the category sidebar (120px, left side).
+    fn render_category_sidebar(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        let selected = self.state.selected_category;
+
+        div()
+            .id("settings-sidebar")
+            .w(px(120.0))
+            .h_full()
+            .bg(Theme::bg_darkest())
+            .border_r_1()
+            .border_color(Theme::border())
+            .flex()
+            .flex_col()
+            .children(SettingsCategory::ALL.iter().map(|&cat| {
+                let is_active = cat == selected;
+                div()
+                    .id(SharedString::from(format!(
+                        "cat-{}",
+                        cat.display_name().to_lowercase().replace(' ', "-")
+                    )))
+                    .w_full()
+                    .py(px(8.0))
+                    .px(px(12.0))
+                    .cursor_pointer()
+                    .border_l_2()
+                    .when(is_active, |d| {
+                        d.border_color(Theme::accent())
+                            .bg(Theme::bg_dark())
+                            .font_weight(FontWeight::SEMIBOLD)
+                    })
+                    .when(!is_active, |d| {
+                        d.border_color(gpui::transparent_black())
+                            .hover(|s| s.bg(Theme::bg_dark()))
+                    })
+                    .text_size(px(12.0))
+                    .text_color(Theme::text_primary())
+                    .child(cat.display_name())
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, _window, cx| {
+                            this.select_category(cat);
+                            cx.notify();
+                        }),
+                    )
+                    .into_any_element()
+            }))
+    }
+
+    /// Dispatch to the appropriate category panel renderer.
+    fn render_content_panel(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        let panel: gpui::AnyElement = match self.state.selected_category {
+            SettingsCategory::General => self.render_general_panel(cx).into_any_element(),
+            SettingsCategory::Models => self.render_models_panel(cx).into_any_element(),
+            SettingsCategory::Security => self.render_security_panel(cx).into_any_element(),
+            SettingsCategory::McpTools => self.render_mcp_tools_panel(cx).into_any_element(),
+        };
+
+        div()
+            .id("settings-content-panel")
+            .flex_1()
+            .h_full()
+            .p(px(12.0))
+            .overflow_hidden()
+            .flex()
+            .flex_col()
+            .child(panel)
+    }
+
+    /// General panel: theme dropdown trigger + export directory.
+    fn render_general_panel(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
         let themes = &self.state.available_themes;
         let selected_name = themes
             .iter()
@@ -697,53 +690,203 @@ impl SettingsView {
         div()
             .flex()
             .flex_col()
-            .gap(px(6.0))
-            // Section header
+            .gap(px(16.0))
+            // Theme dropdown trigger
             .child(
                 div()
-                    .text_size(px(11.0))
-                    .text_color(Theme::text_primary())
-                    .child("THEME"),
-            )
-            // Current selection indicator
-            .child(
-                div()
-                    .w_full()
-                    .h(px(24.0))
-                    .px(px(8.0))
-                    .bg(Theme::bg_dark())
-                    .border_1()
-                    .border_color(Theme::border())
-                    .rounded(px(4.0))
-                    .flex()
-                    .items_center()
-                    .text_size(px(12.0))
-                    .text_color(Theme::text_primary())
-                    .child(selected_name),
-            )
-            // Theme list
-            .child(
-                div()
-                    .id("themes-list")
-                    .w_full()
-                    .h(px(80.0))
-                    .bg(Theme::bg_darker())
-                    .border_1()
-                    .border_color(Theme::border())
-                    .rounded(px(4.0))
-                    .overflow_y_scroll()
                     .flex()
                     .flex_col()
-                    .children(themes.iter().map(|t| self.render_theme_row(t, cx)))
-                    .when(themes.is_empty(), |d| {
-                        d.items_center().justify_center().child(
-                            div()
-                                .text_size(px(12.0))
-                                .text_color(Theme::text_muted())
-                                .child("No themes available"),
-                        )
-                    }),
+                    .gap(px(6.0))
+                    .child(
+                        div()
+                            .text_size(px(11.0))
+                            .text_color(Theme::text_primary())
+                            .child("THEME"),
+                    )
+                    .child(
+                        div()
+                            .id("theme-dropdown-trigger")
+                            .w_full()
+                            .h(px(28.0))
+                            .px(px(8.0))
+                            .bg(Theme::bg_dark())
+                            .border_1()
+                            .border_color(if self.state.theme_dropdown_open {
+                                Theme::accent()
+                            } else {
+                                Theme::border()
+                            })
+                            .rounded(px(4.0))
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .cursor_pointer()
+                            .text_size(px(12.0))
+                            .text_color(Theme::text_primary())
+                            .child(selected_name)
+                            .child(
+                                div()
+                                    .text_size(px(10.0))
+                                    .text_color(Theme::text_muted())
+                                    .child(if self.state.theme_dropdown_open {
+                                        "▲"
+                                    } else {
+                                        "▼"
+                                    }),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _window, cx| {
+                                    this.toggle_theme_dropdown();
+                                    cx.notify();
+                                }),
+                            ),
+                    ),
             )
+            // Export directory section
+            .child(self.render_export_dir_section(cx))
+    }
+
+    /// Models panel: full-height profiles list + Refresh Models button.
+    fn render_models_panel(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .gap(px(6.0))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .child(
+                        div()
+                            .text_size(px(11.0))
+                            .text_color(Theme::text_primary())
+                            .child("PROFILES"),
+                    )
+                    .child(
+                        div()
+                            .id("btn-refresh-models")
+                            .px(px(12.0))
+                            .py(px(4.0))
+                            .rounded(px(4.0))
+                            .cursor_pointer()
+                            .hover(|s| s.bg(Theme::bg_dark()))
+                            .text_size(px(11.0))
+                            .text_color(Theme::text_primary())
+                            .child("Refresh Models")
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _window, _cx| {
+                                    this.emit(&UserEvent::RefreshModelsRegistry);
+                                }),
+                            ),
+                    ),
+            )
+            .child(self.render_profiles_section(cx))
+    }
+
+    /// Security panel: reuses the tool approval section.
+    fn render_security_panel(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        div()
+            .id("security-panel-scroll")
+            .flex()
+            .flex_col()
+            .flex_1()
+            .overflow_y_scroll()
+            .child(self.render_tool_approval_section(cx))
+    }
+
+    /// MCP Tools panel: full-height MCP server list.
+    fn render_mcp_tools_panel(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        self.render_mcp_section(cx)
+    }
+
+    /// Render backdrop for theme dropdown (click to dismiss).
+    #[allow(clippy::unused_self)]
+    fn render_theme_dropdown_backdrop(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        div()
+            .id("theme-dropdown-backdrop")
+            .absolute()
+            .top_0()
+            .left_0()
+            .size_full()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _window, cx| {
+                    this.close_theme_dropdown();
+                    cx.notify();
+                }),
+            )
+    }
+
+    /// Render the theme dropdown menu overlay.
+    fn render_theme_dropdown_menu(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        let themes = &self.state.available_themes;
+
+        div()
+            .id("theme-dropdown-menu")
+            .absolute()
+            // Position below the top bar (44px) + sidebar item + some padding
+            .top(px(120.0))
+            .left(px(140.0))
+            .w(px(200.0))
+            .max_h(px(200.0))
+            .bg(Theme::bg_dark())
+            .border_1()
+            .border_color(Theme::accent())
+            .rounded(px(4.0))
+            .overflow_y_scroll()
+            .flex()
+            .flex_col()
+            .children(themes.iter().map(|t| self.render_theme_row(t, cx)))
+            .when(themes.is_empty(), |d| {
+                d.items_center().justify_center().child(
+                    div()
+                        .text_size(px(12.0))
+                        .text_color(Theme::text_muted())
+                        .child("No themes available"),
+                )
+            })
+    }
+
+    /// Render a single row in the theme dropdown list.
+    fn render_theme_row(
+        &self,
+        option: &super::ThemeOption,
+        cx: &mut gpui::Context<Self>,
+    ) -> gpui::AnyElement {
+        let slug = option.slug.clone();
+        let name = option.name.clone();
+        let is_selected = self.state.selected_theme_slug == slug;
+
+        div()
+            .id(gpui::SharedString::from(format!("theme-{slug}")))
+            .w_full()
+            .h(px(24.0))
+            .px(px(8.0))
+            .flex()
+            .items_center()
+            .cursor_pointer()
+            .when(is_selected, |d| {
+                d.bg(Theme::selection_bg())
+                    .text_color(Theme::selection_fg())
+            })
+            .when(!is_selected, |d| {
+                d.hover(|s| s.bg(Theme::bg_dark()))
+                    .text_color(Theme::text_primary())
+            })
+            .text_size(px(12.0))
+            .child(name)
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(move |this, _, _window, cx| {
+                    tracing::info!("Theme selected: {}", slug);
+                    this.select_theme_from_dropdown(slug.clone(), cx);
+                }),
+            )
+            .into_any_element()
     }
 }
 
@@ -759,6 +902,8 @@ impl gpui::Render for SettingsView {
         _window: &mut gpui::Window,
         cx: &mut gpui::Context<Self>,
     ) -> impl IntoElement {
+        let dropdown_open = self.state.theme_dropdown_open;
+
         div()
             .id("settings-view")
             .flex()
@@ -794,27 +939,22 @@ impl gpui::Render for SettingsView {
             )
             // Top bar (44px)
             .child(Self::render_top_bar(cx))
-            // Content scroll area
+            // Body: sidebar + content panel
             .child(
                 div()
-                    .id("settings-scroll-area")
+                    .id("settings-body")
                     .flex_1()
                     .w_full()
-                    .p(px(12.0))
                     .flex()
-                    .flex_col()
-                    .gap(px(16.0))
-                    .overflow_y_scroll()
-                    // Profiles section
-                    .child(self.render_profiles_section(cx))
-                    // MCP Tools section
-                    .child(self.render_mcp_section(cx))
-                    // Tool approval section
-                    .child(self.render_tool_approval_section(cx))
-                    // Export directory section
-                    .child(self.render_export_dir_section(cx))
-                    // Theme section
-                    .child(self.render_theme_section(cx)),
+                    .flex_row()
+                    .overflow_hidden()
+                    .child(self.render_category_sidebar(cx))
+                    .child(self.render_content_panel(cx)),
             )
+            // Theme dropdown overlay (rendered at root level for z-ordering)
+            .when(dropdown_open, |d| {
+                d.child(self.render_theme_dropdown_backdrop(cx))
+                    .child(self.render_theme_dropdown_menu(cx))
+            })
     }
 }

--- a/src/ui_gpui/views/settings_view/tests.rs
+++ b/src/ui_gpui/views/settings_view/tests.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::future_not_send)]
 
+#[path = "tests_category.rs"]
+mod tests_category;
+
 use super::*;
 use crate::presentation::view_command::{ViewCommand, ViewId};
 use gpui::AppContext;
@@ -367,6 +370,8 @@ async fn key_handling_navigates_and_emits_profile_events(cx: &mut TestAppContext
         view.set_mcps(vec![McpItem::new(mcp_a, "Fetcher").with_enabled(true)]);
         view.state.selected_profile_id = Some(profile_b);
 
+        // Arrow keys on Models category scroll profiles
+        view.select_category(SettingsCategory::Models);
         view.handle_key_down(&settings_key_event("up"), cx);
         assert_eq!(view.state.selected_profile_id, Some(profile_a));
 
@@ -387,6 +392,9 @@ async fn key_handling_navigates_and_emits_profile_events(cx: &mut TestAppContext
             Some(ViewId::McpAdd)
         );
 
+        // Theme scrolling requires General category with dropdown open
+        view.select_category(SettingsCategory::General);
+        view.state.theme_dropdown_open = true;
         view.state.available_themes = vec![
             ThemeOption {
                 name: "Green Screen".to_string(),
@@ -401,6 +409,7 @@ async fn key_handling_navigates_and_emits_profile_events(cx: &mut TestAppContext
         view.handle_key_down(&settings_key_event("down"), cx);
         assert_eq!(view.state.selected_theme_slug, "default");
         view.handle_key_down(&settings_key_event("enter"), cx);
+        assert!(!view.state.theme_dropdown_open, "enter closes dropdown");
 
         view.handle_key_down(&settings_key_event("cmd-w"), cx);
         assert_eq!(
@@ -420,10 +429,6 @@ async fn key_handling_navigates_and_emits_profile_events(cx: &mut TestAppContext
     assert_eq!(
         user_rx.recv().unwrap(),
         UserEvent::EditProfile { id: profile_b }
-    );
-    assert_eq!(
-        user_rx.recv().unwrap(),
-        UserEvent::SelectProfile { id: profile_b }
     );
     assert_eq!(
         user_rx.recv().unwrap(),

--- a/src/ui_gpui/views/settings_view/tests_category.rs
+++ b/src/ui_gpui/views/settings_view/tests_category.rs
@@ -1,0 +1,269 @@
+//! Tests for category sidebar, theme dropdown, and scoped keyboard navigation.
+
+#![allow(clippy::future_not_send)]
+
+use super::*;
+use crate::events::types::UserEvent;
+use gpui::TestAppContext;
+use std::sync::Arc;
+
+fn make_bridge() -> (Arc<GpuiBridge>, flume::Receiver<UserEvent>) {
+    let (user_tx, user_rx) = flume::bounded(16);
+    let (_view_tx, view_rx) = flume::bounded(16);
+    (Arc::new(GpuiBridge::new(user_tx, view_rx)), user_rx)
+}
+
+fn settings_key_event(key: &str) -> gpui::KeyDownEvent {
+    gpui::KeyDownEvent {
+        keystroke: gpui::Keystroke::parse(key).unwrap_or_else(|_| panic!("{key} keystroke")),
+        is_held: false,
+        prefer_character_input: false,
+    }
+}
+
+#[gpui::test]
+async fn settings_state_default_has_category_and_dropdown_fields(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.read_with(cx, |view, _cx| {
+        assert_eq!(
+            view.state.selected_category,
+            SettingsCategory::General,
+            "default category should be General"
+        );
+        assert!(
+            !view.state.theme_dropdown_open,
+            "dropdown should be closed by default"
+        );
+    });
+}
+
+#[gpui::test]
+async fn select_category_updates_state_and_closes_dropdown(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        view.state.theme_dropdown_open = true;
+
+        view.select_category(SettingsCategory::Models);
+        assert_eq!(view.state.selected_category, SettingsCategory::Models);
+        assert!(
+            !view.state.theme_dropdown_open,
+            "selecting a category should close dropdown"
+        );
+
+        view.select_category(SettingsCategory::Security);
+        assert_eq!(view.state.selected_category, SettingsCategory::Security);
+
+        view.select_category(SettingsCategory::McpTools);
+        assert_eq!(view.state.selected_category, SettingsCategory::McpTools);
+
+        view.select_category(SettingsCategory::General);
+        assert_eq!(view.state.selected_category, SettingsCategory::General);
+    });
+}
+
+#[gpui::test]
+async fn toggle_theme_dropdown_toggles_state(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        assert!(!view.state.theme_dropdown_open);
+        view.toggle_theme_dropdown();
+        assert!(view.state.theme_dropdown_open);
+        view.toggle_theme_dropdown();
+        assert!(!view.state.theme_dropdown_open);
+    });
+}
+
+#[gpui::test]
+async fn close_theme_dropdown_sets_false(cx: &mut TestAppContext) {
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        view.state.theme_dropdown_open = true;
+        view.close_theme_dropdown();
+        assert!(!view.state.theme_dropdown_open);
+
+        view.close_theme_dropdown();
+        assert!(!view.state.theme_dropdown_open);
+    });
+}
+
+#[gpui::test]
+async fn select_theme_from_dropdown_selects_and_closes(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, cx| {
+        view.state.available_themes = vec![
+            ThemeOption {
+                name: "Green Screen".to_string(),
+                slug: "green-screen".to_string(),
+            },
+            ThemeOption {
+                name: "Midnight Nebula".to_string(),
+                slug: "default".to_string(),
+            },
+        ];
+        view.state.theme_dropdown_open = true;
+        view.select_theme_from_dropdown("default".to_string(), cx);
+        assert_eq!(view.state.selected_theme_slug, "default");
+        assert!(!view.state.theme_dropdown_open);
+    });
+
+    assert_eq!(
+        user_rx.try_recv().unwrap(),
+        UserEvent::SelectTheme {
+            slug: "default".to_string()
+        }
+    );
+}
+
+#[gpui::test]
+async fn arrow_keys_only_scroll_profiles_on_models_category(cx: &mut TestAppContext) {
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let mcp_a = Uuid::new_v4();
+    let mcp_b = Uuid::new_v4();
+    let (bridge, _user_rx) = make_bridge();
+    let view = cx.new(|cx| {
+        let mut v = SettingsView::new(cx);
+        v.bridge = Some(bridge);
+        v
+    });
+
+    view.update(cx, |view, cx| {
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha"),
+            ProfileItem::new(profile_b, "Beta"),
+        ]);
+        view.set_mcps(vec![
+            McpItem::new(mcp_a, "First"),
+            McpItem::new(mcp_b, "Second"),
+        ]);
+        view.state.selected_profile_id = Some(profile_a);
+        view.state.selected_mcp_id = Some(mcp_a);
+
+        view.select_category(SettingsCategory::Models);
+        view.handle_key_down(&settings_key_event("down"), cx);
+        assert_eq!(view.state.selected_profile_id, Some(profile_b));
+        assert_eq!(
+            view.state.selected_mcp_id,
+            Some(mcp_a),
+            "MCP selection unchanged when on Models"
+        );
+    });
+}
+
+#[gpui::test]
+async fn arrow_keys_only_scroll_mcps_on_mcp_tools_category(cx: &mut TestAppContext) {
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let mcp_a = Uuid::new_v4();
+    let mcp_b = Uuid::new_v4();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, cx| {
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha"),
+            ProfileItem::new(profile_b, "Beta"),
+        ]);
+        view.set_mcps(vec![
+            McpItem::new(mcp_a, "First"),
+            McpItem::new(mcp_b, "Second"),
+        ]);
+        view.state.selected_profile_id = Some(profile_a);
+        view.state.selected_mcp_id = Some(mcp_a);
+
+        view.select_category(SettingsCategory::McpTools);
+        view.handle_key_down(&settings_key_event("down"), cx);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_b));
+        assert_eq!(
+            view.state.selected_profile_id,
+            Some(profile_a),
+            "Profile selection unchanged when on McpTools"
+        );
+    });
+}
+
+#[gpui::test]
+async fn arrow_keys_do_nothing_on_general_without_dropdown(cx: &mut TestAppContext) {
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, cx| {
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha"),
+            ProfileItem::new(profile_b, "Beta"),
+        ]);
+        view.state.selected_profile_id = Some(profile_a);
+
+        view.select_category(SettingsCategory::General);
+        view.handle_key_down(&settings_key_event("down"), cx);
+        assert_eq!(
+            view.state.selected_profile_id,
+            Some(profile_a),
+            "profiles unchanged on General"
+        );
+    });
+}
+
+#[gpui::test]
+async fn arrow_keys_do_nothing_on_security_category(cx: &mut TestAppContext) {
+    let profile_a = Uuid::new_v4();
+    let profile_b = Uuid::new_v4();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, cx| {
+        view.set_profiles(vec![
+            ProfileItem::new(profile_a, "Alpha"),
+            ProfileItem::new(profile_b, "Beta"),
+        ]);
+        view.state.selected_profile_id = Some(profile_a);
+
+        view.select_category(SettingsCategory::Security);
+        view.handle_key_down(&settings_key_event("down"), cx);
+        assert_eq!(
+            view.state.selected_profile_id,
+            Some(profile_a),
+            "profiles unchanged on Security"
+        );
+    });
+}
+
+#[gpui::test]
+async fn settings_category_display_names(cx: &mut TestAppContext) {
+    let _ = cx;
+    assert_eq!(SettingsCategory::General.display_name(), "General");
+    assert_eq!(SettingsCategory::Models.display_name(), "Models");
+    assert_eq!(SettingsCategory::Security.display_name(), "Security");
+    assert_eq!(SettingsCategory::McpTools.display_name(), "MCP Tools");
+}
+
+#[gpui::test]
+async fn scroll_mcps_clamps_correctly(cx: &mut TestAppContext) {
+    let mcp_a = Uuid::new_v4();
+    let mcp_b = Uuid::new_v4();
+    let view = cx.new(SettingsView::new);
+
+    view.update(cx, |view, _cx| {
+        view.set_mcps(vec![
+            McpItem::new(mcp_a, "First"),
+            McpItem::new(mcp_b, "Second"),
+        ]);
+        view.state.selected_mcp_id = Some(mcp_a);
+
+        view.scroll_mcps(1);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_b));
+        view.scroll_mcps(20);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_b));
+        view.scroll_mcps(-20);
+        assert_eq!(view.state.selected_mcp_id, Some(mcp_a));
+    });
+}

--- a/tests/settings_view_tests.rs
+++ b/tests/settings_view_tests.rs
@@ -1,7 +1,9 @@
 use personal_agent::presentation::view_command::{
     McpStatus as CommandMcpStatus, ProfileSummary, ThemeSummary,
 };
-use personal_agent::ui_gpui::views::{McpItem, McpStatus, ProfileItem, SettingsState, ThemeOption};
+use personal_agent::ui_gpui::views::{
+    McpItem, McpStatus, ProfileItem, SettingsCategory, SettingsState, ThemeOption,
+};
 use uuid::Uuid;
 
 fn apply_theme_options(options: &[ThemeOption], selected_slug: &str) -> (Vec<String>, usize) {
@@ -273,6 +275,8 @@ fn settings_state_new_uses_expected_defaults() {
     assert_eq!(state.selected_mcp_id, None);
     assert!(state.available_themes.is_empty());
     assert_eq!(state.selected_theme_slug, "green-screen");
+    assert_eq!(state.selected_category, SettingsCategory::General);
+    assert!(!state.theme_dropdown_open);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Replaces the vertically-stacked scrollable settings layout with a **category sidebar + content panel** design that eliminates nested scroll conflicts.

## Changes

### State Foundation
- Added `SettingsCategory` enum (`General`, `Models`, `Security`, `McpTools`) with `display_name()` and `ALL` constant
- Extended `SettingsState` with `selected_category` and `theme_dropdown_open` fields
- Added helper methods: `select_category()`, `toggle_theme_dropdown()`, `close_theme_dropdown()`, `select_theme_from_dropdown()`, `scroll_mcps()`

### Layout Restructure
- Root render now uses a flex-row body: 120px sidebar + flex-1 content panel with `overflow_hidden`
- Category sidebar shows all four categories with active indicator (left border accent)
- Content panel dispatches to category-specific renderers

### Category Panels
- **General**: Theme dropdown trigger (click to open/close) + export directory section
- **Models**: Full-height profiles list (`flex_1`) + Refresh Models button (moved from top bar)
- **Security**: Scrollable tool approval section (reuses existing renderer)
- **MCP Tools**: Full-height MCP server list (`flex_1`)

### Theme Dropdown
- Dropdown trigger shows current theme name with chevron indicator
- Backdrop + overlay menu rendered at root level for proper z-ordering
- Click backdrop or select theme to dismiss

### Keyboard Navigation
- Arrow keys now scoped to active category (fixes bug where up/down scrolled both profiles and themes simultaneously)
- Models: arrows scroll profiles only
- MCP Tools: arrows scroll MCP list only
- General with dropdown open: arrows scroll theme list
- General/Security without dropdown: arrows do nothing

### Top Bar
- Simplified: removed Refresh Models button (moved to Models panel)

## Tests
- Updated existing `key_handling_navigates_and_emits_profile_events` for category-scoped behavior
- Added tests for: category switching, dropdown toggle/close, theme selection from dropdown, arrow key scoping per category, MCP scrolling, display names
- Updated integration tests to verify new default fields

Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned settings interface with sidebar navigation for General, Models, Security, and MCP Tools categories.
  * Implemented dropdown-based theme selection within the General settings panel.
  * Relocated "Refresh Models" action from the top bar to the Models settings panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->