### PR TITLE
Keep GPUI chat controls stable after send and refresh history deletes (Fixes #110)

### DIFF
--- a/src/ui_gpui/views/chat_view/mod.rs
+++ b/src/ui_gpui/views/chat_view/mod.rs
@@ -764,6 +764,9 @@ impl ChatView {
         self.state.input_text.clear();
         self.state.cursor_position = 0;
         self.state.chat_autoscroll_enabled = true;
+        self.state.conversation_dropdown_open = false;
+        self.state.profile_dropdown_open = false;
+        self.state.conversation_title_editing = false;
         self.state.streaming = StreamingState::Streaming {
             content: String::new(),
             done: false,

--- a/src/ui_gpui/views/chat_view/mod_tests.rs
+++ b/src/ui_gpui/views/chat_view/mod_tests.rs
@@ -397,6 +397,9 @@ async fn send_message_and_start_streaming_reenables_autoscroll_and_starts_stream
             view.state.chat_autoscroll_enabled = false;
             view.state.input_text = "queued".to_string();
             view.state.cursor_position = view.state.input_text.len();
+            view.state.conversation_dropdown_open = true;
+            view.state.profile_dropdown_open = true;
+            view.state.conversation_title_editing = true;
             view.maybe_scroll_chat_to_bottom_invocations.set(0);
 
             view.send_message_and_start_streaming("hello".to_string(), cx);
@@ -404,6 +407,9 @@ async fn send_message_and_start_streaming_reenables_autoscroll_and_starts_stream
             assert!(view.state.chat_autoscroll_enabled);
             assert!(view.state.input_text.is_empty());
             assert_eq!(view.state.cursor_position, 0);
+            assert!(!view.state.conversation_dropdown_open);
+            assert!(!view.state.profile_dropdown_open);
+            assert!(!view.state.conversation_title_editing);
             assert_eq!(
                 view.state.streaming,
                 StreamingState::Streaming {


### PR DESCRIPTION
## Summary
- close transient chat UI overlays and rename mode when sending so the title bar layout stays stable after a post
- emit a history refresh command after successful conversation deletion so the History view updates immediately
- extend regression coverage for the send-path UI reset and history delete presenter flow

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --tests
- . .venv-lizard/bin/activate && python -m lizard -C 50 -L 100 -w src/ --exclude "src/main_gpui.rs" --exclude "src/bin/*" --exclude "src/services/chat.rs" --exclude "src/llm/client_agent.rs"
- cargo coverage

Fixes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UI state management to ensure conversation and profile dropdowns, along with title editing mode, are properly closed when sending a message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->