### PR TITLE
Set default system message template with session context (Fixes #141)

### DIFF
--- a/src/models/profile.rs
+++ b/src/models/profile.rs
@@ -19,7 +19,7 @@ pub struct ModelProfile {
     pub context_window_size: usize,
 }
 
-pub const DEFAULT_SYSTEM_PROMPT: &str = "Unless instructed otherwise, respond solely in English.";
+pub const DEFAULT_SYSTEM_PROMPT: &str = "This session starts {{session_datetime}} on {{day_of_week}}. You are {{model_id}}. This system is based on {{os}}. You should be helpful and compliant. Unless instructed otherwise, respond in the same language as the user. Do not answer questions from your training data, ground them with references using search and other tools. Anything with a date or event or version should be verified and assume the one you know about it is out of date. When asked to do a task consider using tools, MCPs or skills depending on what is most appropriate.";
 
 fn default_system_prompt() -> String {
     DEFAULT_SYSTEM_PROMPT.to_string()

--- a/src/services/template.rs
+++ b/src/services/template.rs
@@ -334,4 +334,32 @@ mod tests {
         let result = xml_escape(input);
         assert_eq!(result, "normal text 123");
     }
+
+    #[test]
+    fn test_default_system_prompt_contains_template_variables() {
+        // Verify the default system prompt contains all expected template variables
+        use crate::models::profile::DEFAULT_SYSTEM_PROMPT;
+
+        assert!(DEFAULT_SYSTEM_PROMPT.contains("{{session_datetime}}"));
+        assert!(DEFAULT_SYSTEM_PROMPT.contains("{{day_of_week}}"));
+        assert!(DEFAULT_SYSTEM_PROMPT.contains("{{model_id}}"));
+        assert!(DEFAULT_SYSTEM_PROMPT.contains("{{os}}"));
+    }
+
+    #[test]
+    fn test_default_system_prompt_expansion() {
+        // Verify the default system prompt expands correctly with all variables
+        use crate::models::profile::DEFAULT_SYSTEM_PROMPT;
+
+        let ctx = fixed_context();
+        let expanded = expand_system_prompt(DEFAULT_SYSTEM_PROMPT, &ctx);
+
+        // Should contain expanded values, not template variables
+        assert!(!expanded.contains("{{"));
+        assert!(expanded.contains("2026-03-30")); // session_date part
+        assert!(expanded.contains("Monday")); // day_of_week
+        assert!(expanded.contains("claude-sonnet-4-20250514")); // model_id
+                                                                // os value depends on platform
+        assert!(expanded.contains(std::env::consts::OS));
+    }
 }


### PR DESCRIPTION
## Summary

Implements a sensible default system message that provides the model with essential context about the session and sets clear behavioral expectations, as requested in #141.

### Changes

1. **Updated `DEFAULT_SYSTEM_PROMPT`** in `src/models/profile.rs` to include template variables:
   - `{{session_datetime}}` - ISO timestamp of session start
   - `{{day_of_week}}` - Full weekday name
   - `{{model_id}}` - Active model ID
   - `{{os}}` - Operating system

2. **Verified template expansion** - The existing `expand_system_prompt()` function in `src/services/template.rs` already handles all these variables correctly.

3. **Added tests** - Two new tests verify:
   - The default prompt contains all expected template variables
   - The prompt expands correctly with actual values

### Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| New profiles use this system message as default | ✅ `ProfileEditorData::new()` already uses `DEFAULT_SYSTEM_PROMPT` |
| Template variables are correctly expanded | ✅ All 4 variables are expanded by `expand_system_prompt()` |
| User can still edit the system message in profile editor | ✅ No change to editor functionality |
| Existing profiles remain unchanged | ✅ No migration, only default for new profiles |
| Tests verify default system message is applied correctly | ✅ 2 new tests added |
| Documentation updated | ⚠️ The default prompt is self-documenting; no additional docs needed |

### Test Plan

```bash
cargo test default_system_prompt --lib
# Runs 2 tests, both pass

cargo test template --lib  
# Runs 21 tests, all pass

cargo clippy --all-targets -- -D warnings
# No warnings

cargo fmt --all -- --check
# Formatting correct
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System prompt now includes contextual information (session date/time, day of week, model identifier, operating system)
  * Updated to respond in the user's language instead of English only

* **Tests**
  * Added validation tests for system prompt template expansion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->