### PR TITLE
Add clickable link support in messages (Fixes #153)

### DIFF
--- a/src/ui_gpui/components/markdown_content.rs
+++ b/src/ui_gpui/components/markdown_content.rs
@@ -304,32 +304,48 @@ fn extract_language(info: &str) -> Option<String> {
 ///
 /// Phase 2 of the two-phase IR pipeline. This function takes the IR produced
 /// by `parse_markdown_blocks()` and constructs GPUI elements for rendering.
+/// Uses text_primary() for text color.
 ///
 /// @plan:PLAN-20260402-MARKDOWN.P06
 pub(crate) fn blocks_to_elements(blocks: &[MarkdownBlock]) -> Vec<gpui::AnyElement> {
+    blocks_to_elements_with_color(blocks, crate::ui_gpui::theme::Theme::text_primary())
+}
+
+/// Phase 2 variant that accepts a custom text color.
+/// Used by user message bubbles which need user_bubble_text() color.
+///
+/// @plan:PLAN-20260402-ISSUE153.P02
+pub(crate) fn blocks_to_elements_with_color(
+    blocks: &[MarkdownBlock],
+    text_color: gpui::Hsla,
+) -> Vec<gpui::AnyElement> {
     blocks
         .iter()
         .map(|block| match block {
-            MarkdownBlock::Paragraph { spans, links } => render_paragraph(spans, links),
+            MarkdownBlock::Paragraph { spans, links } => {
+                render_paragraph_with_color(spans, links, text_color)
+            }
             MarkdownBlock::Heading {
                 level,
                 spans,
                 links,
-            } => render_heading(*level, spans, links),
+            } => render_heading_with_color(*level, spans, links, text_color),
             MarkdownBlock::CodeBlock { language, code } => {
                 render_code_block(language.as_ref(), code)
             }
-            MarkdownBlock::BlockQuote { blocks } => render_blockquote(blocks),
+            MarkdownBlock::BlockQuote { blocks } => {
+                render_blockquote_with_color(blocks, text_color)
+            }
             MarkdownBlock::List {
                 ordered,
                 start,
                 items,
-            } => render_list(*ordered, *start, items),
+            } => render_list_with_color(*ordered, *start, items, text_color),
             MarkdownBlock::Table {
                 alignments,
                 header,
                 rows,
-            } => render_table(alignments, header, rows),
+            } => render_table_with_color(alignments, header, rows, text_color),
             MarkdownBlock::ThematicBreak => render_thematic_break(),
             MarkdownBlock::ImageFallback { alt } => render_image_fallback(alt),
         })
@@ -371,15 +387,16 @@ pub(crate) fn is_safe_url(raw: &str) -> bool {
 
 /// @plan:PLAN-20260402-MARKDOWN.P06
 /// @requirement:REQ-MD-RENDER-023
-fn inline_to_text_run(span: &MarkdownInline) -> gpui::TextRun {
+fn inline_to_text_run(span: &MarkdownInline, text_color: gpui::Hsla) -> gpui::TextRun {
     use gpui::{font, FontStyle, FontWeight, StrikethroughStyle, TextRun, UnderlineStyle};
 
+    // For links, use accent color. For non-links, use the provided text_color
     let mut run = TextRun {
         len: span.text.len(),
         color: if span.link_url.is_some() {
             crate::ui_gpui::theme::Theme::accent()
         } else {
-            crate::ui_gpui::theme::Theme::text_primary()
+            text_color
         },
         ..Default::default()
     };
@@ -417,6 +434,7 @@ fn inline_to_text_run(span: &MarkdownInline) -> gpui::TextRun {
 fn spans_to_styled_text(
     spans: &[MarkdownInline],
     links: &[(Range<usize>, String)],
+    text_color: gpui::Hsla,
 ) -> gpui::AnyElement {
     use gpui::StyledText;
 
@@ -424,7 +442,7 @@ fn spans_to_styled_text(
     let mut runs = Vec::with_capacity(spans.len());
     for span in spans {
         text.push_str(&span.text);
-        runs.push(inline_to_text_run(span));
+        runs.push(inline_to_text_run(span, text_color));
     }
 
     let styled = StyledText::new(text).with_runs(runs);
@@ -457,25 +475,24 @@ fn spans_to_styled_text(
         .into_any_element()
 }
 
-/// @plan:PLAN-20260402-MARKDOWN.P06
-/// @requirement:REQ-MD-RENDER-001
-fn render_paragraph(
+/// @plan:PLAN-20260402-ISSUE153.P02
+fn render_paragraph_with_color(
     spans: &[MarkdownInline],
     links: &[(Range<usize>, String)],
+    text_color: gpui::Hsla,
 ) -> gpui::AnyElement {
     div()
         .text_size(px(crate::ui_gpui::theme::Theme::font_size_body()))
-        .text_color(crate::ui_gpui::theme::Theme::text_primary())
-        .child(spans_to_styled_text(spans, links))
+        .child(spans_to_styled_text(spans, links, text_color))
         .into_any_element()
 }
 
-/// @plan:PLAN-20260402-MARKDOWN.P06
-/// @requirement:REQ-MD-RENDER-003
-fn render_heading(
+/// @plan:PLAN-20260402-ISSUE153.P02
+fn render_heading_with_color(
     level: u8,
     spans: &[MarkdownInline],
     links: &[(Range<usize>, String)],
+    text_color: gpui::Hsla,
 ) -> gpui::AnyElement {
     let size = match level {
         1 => crate::ui_gpui::theme::Theme::font_size_h1(),
@@ -491,8 +508,7 @@ fn render_heading(
         .min_w(px(0.0))
         .text_size(px(size))
         .font_weight(gpui::FontWeight::BOLD)
-        .text_color(crate::ui_gpui::theme::Theme::text_primary())
-        .child(spans_to_styled_text(spans, links))
+        .child(spans_to_styled_text(spans, links, text_color))
         .into_any_element()
 }
 
@@ -525,9 +541,11 @@ fn render_code_block(language: Option<&String>, code: &str) -> gpui::AnyElement 
     block.child(code.to_string()).into_any_element()
 }
 
-/// @plan:PLAN-20260402-MARKDOWN.P06
-/// @requirement:REQ-MD-RENDER-007
-fn render_blockquote(children: &[MarkdownBlock]) -> gpui::AnyElement {
+/// @plan:PLAN-20260402-ISSUE153.P02
+fn render_blockquote_with_color(
+    children: &[MarkdownBlock],
+    text_color: gpui::Hsla,
+) -> gpui::AnyElement {
     div()
         .w_full()
         .border_l_2()
@@ -535,13 +553,17 @@ fn render_blockquote(children: &[MarkdownBlock]) -> gpui::AnyElement {
         .pl(px(crate::ui_gpui::theme::Theme::SPACING_SM))
         .py(px(crate::ui_gpui::theme::Theme::SPACING_XS))
         .bg(crate::ui_gpui::theme::Theme::bg_base())
-        .children(blocks_to_elements(children))
+        .children(blocks_to_elements_with_color(children, text_color))
         .into_any_element()
 }
 
-/// @plan:PLAN-20260402-MARKDOWN.P06
-/// @requirement:REQ-MD-RENDER-008
-fn render_list(ordered: bool, start: u64, items: &[Vec<MarkdownBlock>]) -> gpui::AnyElement {
+/// @plan:PLAN-20260402-ISSUE153.P02
+fn render_list_with_color(
+    ordered: bool,
+    start: u64,
+    items: &[Vec<MarkdownBlock>],
+    text_color: gpui::Hsla,
+) -> gpui::AnyElement {
     let mut list = div()
         .flex()
         .flex_col()
@@ -570,7 +592,7 @@ fn render_list(ordered: bool, start: u64, items: &[Vec<MarkdownBlock>]) -> gpui:
                         .flex()
                         .flex_col()
                         .gap(px(crate::ui_gpui::theme::Theme::SPACING_XS))
-                        .children(blocks_to_elements(item_blocks)),
+                        .children(blocks_to_elements_with_color(item_blocks, text_color)),
                 ),
         );
     }
@@ -578,12 +600,12 @@ fn render_list(ordered: bool, start: u64, items: &[Vec<MarkdownBlock>]) -> gpui:
     list.into_any_element()
 }
 
-/// @plan:PLAN-20260402-MARKDOWN.P06
-/// @requirement:REQ-MD-RENDER-009
-fn render_table(
+/// @plan:PLAN-20260402-ISSUE153.P02
+fn render_table_with_color(
     alignments: &[Alignment],
     header: &[TableCell],
     rows: &[Vec<TableCell>],
+    text_color: gpui::Hsla,
 ) -> gpui::AnyElement {
     let col_count = header
         .len()
@@ -616,7 +638,7 @@ fn render_table(
 
     for (col_idx, cell) in header.iter().enumerate() {
         let alignment = alignments.get(col_idx).unwrap_or(&Alignment::None);
-        let content = spans_to_styled_text(&cell.spans, &cell.links);
+        let content = spans_to_styled_text(&cell.spans, &cell.links, text_color);
 
         table_grid = table_grid.child(
             div()
@@ -634,7 +656,7 @@ fn render_table(
     for (row_idx, row) in rows.iter().enumerate() {
         for (col_idx, cell) in row.iter().enumerate() {
             let alignment = alignments.get(col_idx).unwrap_or(&Alignment::None);
-            let content = spans_to_styled_text(&cell.spans, &cell.links);
+            let content = spans_to_styled_text(&cell.spans, &cell.links, text_color);
 
             table_grid = table_grid.child(
                 div()

--- a/src/ui_gpui/components/markdown_content.rs
+++ b/src/ui_gpui/components/markdown_content.rs
@@ -677,7 +677,10 @@ fn render_image_fallback(alt: &str) -> gpui::AnyElement {
         .into_any_element()
 }
 
+mod autolink;
 mod markdown_parser;
+
+pub(crate) use autolink::apply_autolinks;
 pub(crate) use markdown_parser::parse_markdown_blocks;
 
 #[cfg(test)]

--- a/src/ui_gpui/components/markdown_content/autolink.rs
+++ b/src/ui_gpui/components/markdown_content/autolink.rs
@@ -125,19 +125,27 @@ fn apply_autolinks_to_block(block: &mut MarkdownBlock) {
 /// @plan PLAN-20260402-ISSUE153.P01
 /// @requirement REQ-MD-AUTOLINK-005
 fn apply_autolinks_to_spans(spans: &mut Vec<MarkdownInline>) -> Vec<(Range<usize>, String)> {
-    // First, collect all URLs and their positions in the combined text
+    let all_urls = collect_url_positions(spans);
+
+    if all_urls.is_empty() {
+        return Vec::new();
+    }
+
+    let (new_spans, new_links) = rebuild_spans_with_urls(spans);
+    *spans = new_spans;
+    new_links
+}
+
+/// Collect URL positions from all eligible spans.
+///
+/// @plan PLAN-20260402-ISSUE153.P01
+fn collect_url_positions(spans: &[MarkdownInline]) -> Vec<(Range<usize>, String)> {
     let mut all_urls: Vec<(Range<usize>, String)> = Vec::new();
     let mut byte_offset = 0;
 
-    for span in spans.iter() {
-        // Skip code spans - URLs in code should NOT be autolinked
-        if span.code {
-            byte_offset += span.text.len();
-            continue;
-        }
-
-        // Skip spans that are already part of a link
-        if span.link_url.is_some() {
+    for span in spans {
+        // Skip code spans and already-linked spans
+        if span.code || span.link_url.is_some() {
             byte_offset += span.text.len();
             continue;
         }
@@ -150,17 +158,20 @@ fn apply_autolinks_to_spans(spans: &mut Vec<MarkdownInline>) -> Vec<(Range<usize
         byte_offset += span.text.len();
     }
 
-    // If no URLs found, nothing to do
-    if all_urls.is_empty() {
-        return Vec::new();
-    }
+    all_urls
+}
 
-    // Now rebuild spans with URL splits
+/// Rebuild spans with URL splits.
+///
+/// @plan PLAN-20260402-ISSUE153.P01
+fn rebuild_spans_with_urls(
+    spans: &[MarkdownInline],
+) -> (Vec<MarkdownInline>, Vec<(Range<usize>, String)>) {
     let mut new_spans: Vec<MarkdownInline> = Vec::new();
     let mut new_links: Vec<(Range<usize>, String)> = Vec::new();
-    byte_offset = 0;
+    let mut byte_offset = 0;
 
-    for span in spans.iter() {
+    for span in spans {
         // Skip code spans - preserve as-is
         if span.code {
             new_spans.push(span.clone());
@@ -175,58 +186,66 @@ fn apply_autolinks_to_spans(spans: &mut Vec<MarkdownInline>) -> Vec<(Range<usize
             continue;
         }
 
-        // Find URLs in this span
         let detected = detect_bare_urls(&span.text);
 
         if detected.is_empty() {
-            // No URLs in this span
             new_spans.push(span.clone());
-            byte_offset += span.text.len();
         } else {
-            // Split span at URL boundaries
-            let mut last_end = 0;
-            for (local_range, url) in detected {
-                // Text before URL
-                if local_range.start > last_end {
-                    let before = &span.text[last_end..local_range.start];
-                    if !before.is_empty() {
-                        let mut new_span = span.clone();
-                        new_span.text = before.to_string();
-                        new_spans.push(new_span);
-                    }
-                }
-
-                // URL as a link span
-                let url_text = &span.text[local_range.clone()];
-                let mut url_span = span.clone();
-                url_span.text = url_text.to_string();
-                url_span.link_url = Some(url.clone());
-                new_spans.push(url_span);
-
-                // Record the link range in the new combined text
-                let link_start = byte_offset + last_end;
-                let link_end = link_start + url_text.len();
-                new_links.push((link_start..link_end, url));
-
-                last_end = local_range.end;
-            }
-
-            // Text after last URL
-            if last_end < span.text.len() {
-                let after = &span.text[last_end..];
-                if !after.is_empty() {
-                    let mut new_span = span.clone();
-                    new_span.text = after.to_string();
-                    new_spans.push(new_span);
-                }
-            }
+            split_span_at_urls(span, &detected, &mut new_spans, &mut new_links, byte_offset);
         }
-
         byte_offset += span.text.len();
     }
 
-    *spans = new_spans;
-    new_links
+    (new_spans, new_links)
+}
+
+/// Split a span at URL boundaries.
+///
+/// @plan PLAN-20260402-ISSUE153.P01
+fn split_span_at_urls(
+    span: &MarkdownInline,
+    detected: &[(Range<usize>, String)],
+    new_spans: &mut Vec<MarkdownInline>,
+    new_links: &mut Vec<(Range<usize>, String)>,
+    byte_offset: usize,
+) {
+    let mut last_end = 0;
+
+    for (local_range, url) in detected {
+        // Text before URL
+        if local_range.start > last_end {
+            let before = &span.text[last_end..local_range.start];
+            if !before.is_empty() {
+                let mut new_span = span.clone();
+                new_span.text = before.to_string();
+                new_spans.push(new_span);
+            }
+        }
+
+        // URL as a link span
+        let url_text = &span.text[local_range.clone()];
+        let mut url_span = span.clone();
+        url_span.text = url_text.to_string();
+        url_span.link_url = Some(url.clone());
+        new_spans.push(url_span);
+
+        // Record the link range in the new combined text
+        let link_start = byte_offset + last_end;
+        let link_end = link_start + url_text.len();
+        new_links.push((link_start..link_end, url.clone()));
+
+        last_end = local_range.end;
+    }
+
+    // Text after last URL
+    if last_end < span.text.len() {
+        let after = &span.text[last_end..];
+        if !after.is_empty() {
+            let mut new_span = span.clone();
+            new_span.text = after.to_string();
+            new_spans.push(new_span);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/ui_gpui/components/markdown_content/autolink.rs
+++ b/src/ui_gpui/components/markdown_content/autolink.rs
@@ -1,0 +1,523 @@
+//! URL autolink detection for markdown rendering.
+//!
+//! Implements bare URL detection as a post-processing step on the markdown IR.
+//! This allows URLs like `https://example.com` to be rendered as clickable links
+//! without requiring explicit markdown link syntax `[text](url)`.
+//!
+//! @plan PLAN-20260402-ISSUE153.P01
+//! @requirement REQ-MD-AUTOLINK-001
+
+use regex::Regex;
+use std::ops::Range;
+
+use super::{MarkdownBlock, MarkdownInline};
+
+/// Detect bare URLs in text and return their byte ranges with normalized URLs.
+///
+/// Matches:
+/// - `https?://` URLs
+/// - `www.` URLs (normalized to `https://`)
+///
+/// Strips trailing punctuation (`.`, `,`, `)`, `]`, `!`, `?`) from URLs.
+///
+/// @plan PLAN-20260402-ISSUE153.P01
+/// @requirement REQ-MD-AUTOLINK-002
+pub(crate) fn detect_bare_urls(text: &str) -> Vec<(Range<usize>, String)> {
+    static HTTP_PATTERN: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    static WWW_PATTERN: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+
+    let http_re = HTTP_PATTERN
+        .get_or_init(|| Regex::new(r"https?://[^\s<>\[\]()]+").expect("invalid http URL regex"));
+
+    let www_re = WWW_PATTERN
+        .get_or_init(|| Regex::new(r"www\.[^\s<>\[\]()]+").expect("invalid www URL regex"));
+
+    let mut results: Vec<(Range<usize>, String)> = Vec::new();
+
+    // Collect http/https URLs
+    for m in http_re.find_iter(text) {
+        let url = strip_trailing_punctuation(m.as_str());
+        results.push((m.start()..m.start() + url.len(), url.to_string()));
+    }
+
+    // Collect www URLs and normalize with https://
+    for m in www_re.find_iter(text) {
+        let url = strip_trailing_punctuation(m.as_str());
+        let normalized = format!("https://{url}");
+        results.push((m.start()..m.start() + url.len(), normalized));
+    }
+
+    // Sort by start position and remove overlaps (http takes precedence)
+    results.sort_by_key(|(range, _)| range.start);
+
+    // Remove overlapping matches (prefer earlier matches)
+    let mut deduped: Vec<(Range<usize>, String)> = Vec::with_capacity(results.len());
+    for item in results {
+        if !deduped
+            .iter()
+            .any(|(r, _)| r.start < item.0.end && r.end > item.0.start)
+        {
+            deduped.push(item);
+        }
+    }
+
+    deduped
+}
+
+/// Strip trailing punctuation characters from a URL.
+///
+/// Handles: `.`, `,`, `)`, `]`, `!`, `?`
+///
+/// @plan PLAN-20260402-ISSUE153.P01
+/// @requirement REQ-MD-AUTOLINK-003
+fn strip_trailing_punctuation(url: &str) -> &str {
+    url.trim_end_matches(['.', ',', ')', ']', '!', '?'])
+}
+
+/// Apply autolink detection to markdown blocks.
+///
+/// Scans text spans for bare URLs and splits them into link spans.
+/// This modifies blocks in place.
+///
+/// @plan PLAN-20260402-ISSUE153.P01
+/// @requirement REQ-MD-AUTOLINK-004
+pub(crate) fn apply_autolinks(blocks: &mut [MarkdownBlock]) {
+    for block in blocks.iter_mut() {
+        apply_autolinks_to_block(block);
+    }
+}
+
+fn apply_autolinks_to_block(block: &mut MarkdownBlock) {
+    match block {
+        MarkdownBlock::Paragraph { spans, links } | MarkdownBlock::Heading { spans, links, .. } => {
+            let new_links = apply_autolinks_to_spans(spans);
+            links.extend(new_links);
+        }
+        MarkdownBlock::Table { header, rows, .. } => {
+            for cell in header.iter_mut() {
+                let new_links = apply_autolinks_to_spans(&mut cell.spans);
+                cell.links.extend(new_links);
+            }
+            for row in rows.iter_mut() {
+                for cell in row.iter_mut() {
+                    let new_links = apply_autolinks_to_spans(&mut cell.spans);
+                    cell.links.extend(new_links);
+                }
+            }
+        }
+        MarkdownBlock::BlockQuote { blocks } => {
+            apply_autolinks(blocks);
+        }
+        MarkdownBlock::List { items, .. } => {
+            for item_blocks in items.iter_mut() {
+                apply_autolinks(item_blocks);
+            }
+        }
+        // CodeBlock, ThematicBreak, ImageFallback: no autolinks
+        _ => {}
+    }
+}
+
+/// Apply autolinks to a span vector, splitting spans at URL boundaries.
+///
+/// Returns new link ranges (byte offsets in the combined text).
+///
+/// @plan PLAN-20260402-ISSUE153.P01
+/// @requirement REQ-MD-AUTOLINK-005
+fn apply_autolinks_to_spans(spans: &mut Vec<MarkdownInline>) -> Vec<(Range<usize>, String)> {
+    // First, collect all URLs and their positions in the combined text
+    let mut all_urls: Vec<(Range<usize>, String)> = Vec::new();
+    let mut byte_offset = 0;
+
+    for span in spans.iter() {
+        // Skip code spans - URLs in code should NOT be autolinked
+        if span.code {
+            byte_offset += span.text.len();
+            continue;
+        }
+
+        // Skip spans that are already part of a link
+        if span.link_url.is_some() {
+            byte_offset += span.text.len();
+            continue;
+        }
+
+        let detected = detect_bare_urls(&span.text);
+        for (local_range, url) in detected {
+            let global_range = (byte_offset + local_range.start)..(byte_offset + local_range.end);
+            all_urls.push((global_range, url));
+        }
+        byte_offset += span.text.len();
+    }
+
+    // If no URLs found, nothing to do
+    if all_urls.is_empty() {
+        return Vec::new();
+    }
+
+    // Now rebuild spans with URL splits
+    let mut new_spans: Vec<MarkdownInline> = Vec::new();
+    let mut new_links: Vec<(Range<usize>, String)> = Vec::new();
+    byte_offset = 0;
+
+    for span in spans.iter() {
+        // Skip code spans - preserve as-is
+        if span.code {
+            new_spans.push(span.clone());
+            byte_offset += span.text.len();
+            continue;
+        }
+
+        // Skip spans that are already links - preserve as-is
+        if span.link_url.is_some() {
+            new_spans.push(span.clone());
+            byte_offset += span.text.len();
+            continue;
+        }
+
+        // Find URLs in this span
+        let detected = detect_bare_urls(&span.text);
+
+        if detected.is_empty() {
+            // No URLs in this span
+            new_spans.push(span.clone());
+            byte_offset += span.text.len();
+        } else {
+            // Split span at URL boundaries
+            let mut last_end = 0;
+            for (local_range, url) in detected {
+                // Text before URL
+                if local_range.start > last_end {
+                    let before = &span.text[last_end..local_range.start];
+                    if !before.is_empty() {
+                        let mut new_span = span.clone();
+                        new_span.text = before.to_string();
+                        new_spans.push(new_span);
+                    }
+                }
+
+                // URL as a link span
+                let url_text = &span.text[local_range.clone()];
+                let mut url_span = span.clone();
+                url_span.text = url_text.to_string();
+                url_span.link_url = Some(url.clone());
+                new_spans.push(url_span);
+
+                // Record the link range in the new combined text
+                let link_start = byte_offset + last_end;
+                let link_end = link_start + url_text.len();
+                new_links.push((link_start..link_end, url));
+
+                last_end = local_range.end;
+            }
+
+            // Text after last URL
+            if last_end < span.text.len() {
+                let after = &span.text[last_end..];
+                if !after.is_empty() {
+                    let mut new_span = span.clone();
+                    new_span.text = after.to_string();
+                    new_spans.push(new_span);
+                }
+            }
+        }
+
+        byte_offset += span.text.len();
+    }
+
+    *spans = new_spans;
+    new_links
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ============================================================================
+    // URL DETECTION TESTS
+    // ============================================================================
+
+    #[test]
+    fn test_detect_https_url() {
+        let text = "Visit https://example.com for more";
+        let urls = detect_bare_urls(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].0, 6..25);
+        assert_eq!(urls[0].1, "https://example.com");
+    }
+
+    #[test]
+    fn test_detect_http_url() {
+        let text = "Check http://example.com out";
+        let urls = detect_bare_urls(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].1, "http://example.com");
+    }
+
+    #[test]
+    fn test_detect_www_url() {
+        let text = "See www.example.com for details";
+        let urls = detect_bare_urls(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].1, "https://www.example.com");
+    }
+
+    #[test]
+    fn test_detect_multiple_urls() {
+        let text = "Visit https://example.com and www.test.org";
+        let urls = detect_bare_urls(text);
+        assert_eq!(urls.len(), 2);
+        assert_eq!(urls[0].1, "https://example.com");
+        assert_eq!(urls[1].1, "https://www.test.org");
+    }
+
+    #[test]
+    fn test_strip_trailing_dot() {
+        assert_eq!(
+            strip_trailing_punctuation("https://example.com."),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_strip_trailing_comma() {
+        assert_eq!(
+            strip_trailing_punctuation("https://example.com,"),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_strip_trailing_paren() {
+        assert_eq!(
+            strip_trailing_punctuation("https://example.com)"),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_strip_trailing_bracket() {
+        assert_eq!(
+            strip_trailing_punctuation("https://example.com]"),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_strip_trailing_exclamation() {
+        assert_eq!(
+            strip_trailing_punctuation("https://example.com!"),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_strip_trailing_question() {
+        assert_eq!(
+            strip_trailing_punctuation("https://example.com?"),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_strip_multiple_trailing_punctuation() {
+        // trim_end_matches strips ALL trailing matches
+        assert_eq!(
+            strip_trailing_punctuation("https://example.com!."),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_url_in_sentence_with_punctuation() {
+        let text = "Check out https://example.com, it's great!";
+        let urls = detect_bare_urls(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].1, "https://example.com");
+    }
+
+    #[test]
+    fn test_url_at_end_of_sentence() {
+        let text = "Visit https://example.com.";
+        let urls = detect_bare_urls(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].0, 6..25);
+        assert_eq!(urls[0].1, "https://example.com");
+    }
+
+    // ============================================================================
+    // AUTOLINK INTEGRATION TESTS
+    // ============================================================================
+
+    #[test]
+    fn test_apply_autolinks_to_paragraph() {
+        use super::super::{parse_markdown_blocks, MarkdownBlock};
+
+        let input = "Check https://example.com for info";
+        let mut blocks = parse_markdown_blocks(input);
+        apply_autolinks(&mut blocks);
+
+        match &blocks[0] {
+            MarkdownBlock::Paragraph { spans, links } => {
+                assert!(!spans.is_empty());
+                assert!(!links.is_empty(), "Should have detected URL link");
+                assert!(spans.iter().any(|s| s.link_url.is_some()));
+            }
+            _ => panic!("Expected Paragraph"),
+        }
+    }
+
+    #[test]
+    fn test_apply_autolinks_preserves_code_spans() {
+        use super::super::{parse_markdown_blocks, MarkdownBlock};
+
+        let input = "URL in code: `https://example.com` should not link";
+        let mut blocks = parse_markdown_blocks(input);
+        apply_autolinks(&mut blocks);
+
+        match &blocks[0] {
+            MarkdownBlock::Paragraph { spans, links } => {
+                // Code span should still have code=true and no link_url
+                let code_span = spans.iter().find(|s| s.code);
+                assert!(code_span.is_some());
+                let code_span = code_span.unwrap();
+                assert!(code_span.code);
+                assert!(
+                    code_span.link_url.is_none(),
+                    "Code spans should NOT be autolinked"
+                );
+
+                // No links should be generated
+                assert!(links.is_empty(), "Code URL should not generate link");
+            }
+            _ => panic!("Expected Paragraph"),
+        }
+    }
+
+    #[test]
+    fn test_apply_autolinks_preserves_explicit_links() {
+        use super::super::{parse_markdown_blocks, MarkdownBlock};
+
+        let input = "[click](https://example.com) and also https://test.org";
+        let mut blocks = parse_markdown_blocks(input);
+        apply_autolinks(&mut blocks);
+
+        match &blocks[0] {
+            MarkdownBlock::Paragraph { spans, links } => {
+                // Should have both explicit link and autolink
+                assert_eq!(links.len(), 2, "Should have explicit link and autolink");
+
+                // Check that we have spans with link_url set
+                assert_eq!(
+                    spans.iter().filter(|s| s.link_url.is_some()).count(),
+                    2,
+                    "Should have two link spans"
+                );
+            }
+            _ => panic!("Expected Paragraph"),
+        }
+    }
+
+    #[test]
+    fn test_apply_autolinks_heading() {
+        use super::super::{parse_markdown_blocks, MarkdownBlock};
+
+        let input = "# Visit https://example.com";
+        let mut blocks = parse_markdown_blocks(input);
+        apply_autolinks(&mut blocks);
+
+        match &blocks[0] {
+            MarkdownBlock::Heading { spans, links, .. } => {
+                assert!(!links.is_empty(), "Heading should have autolink");
+                assert!(spans.iter().any(|s| s.link_url.is_some()));
+            }
+            _ => panic!("Expected Heading"),
+        }
+    }
+
+    #[test]
+    fn test_apply_autolinks_table_cell() {
+        use super::super::{parse_markdown_blocks, MarkdownBlock};
+
+        let input = "| URL |\n|---|\n| https://example.com |";
+        let mut blocks = parse_markdown_blocks(input);
+        apply_autolinks(&mut blocks);
+
+        match &blocks[0] {
+            MarkdownBlock::Table { rows, .. } => {
+                assert_eq!(rows.len(), 1);
+                assert!(
+                    !rows[0][0].links.is_empty(),
+                    "Table cell should have autolink"
+                );
+            }
+            _ => panic!("Expected Table"),
+        }
+    }
+
+    #[test]
+    fn test_apply_autolinks_code_block_untouched() {
+        use super::super::{parse_markdown_blocks, MarkdownBlock};
+
+        let input = "```\nhttps://example.com\n```";
+        let mut blocks = parse_markdown_blocks(input);
+        apply_autolinks(&mut blocks);
+
+        match &blocks[0] {
+            MarkdownBlock::CodeBlock { code, .. } => {
+                assert!(code.contains("https://example.com"));
+            }
+            _ => panic!("Expected CodeBlock"),
+        }
+    }
+
+    #[test]
+    fn test_apply_autolinks_www_normalized() {
+        use super::super::{parse_markdown_blocks, MarkdownBlock};
+
+        let input = "Visit www.example.com for more";
+        let mut blocks = parse_markdown_blocks(input);
+        apply_autolinks(&mut blocks);
+
+        match &blocks[0] {
+            MarkdownBlock::Paragraph { spans, links } => {
+                assert!(!links.is_empty());
+                let url_span = spans.iter().find(|s| s.link_url.is_some());
+                assert!(url_span.is_some());
+                let url = url_span.unwrap().link_url.as_ref().unwrap();
+                assert!(
+                    url.starts_with("https://www."),
+                    "www URL should be normalized to https"
+                );
+            }
+            _ => panic!("Expected Paragraph"),
+        }
+    }
+
+    #[test]
+    fn test_apply_autolinks_splits_spans_correctly() {
+        use super::super::{parse_markdown_blocks, MarkdownBlock};
+
+        let input = "Before https://example.com After";
+        let mut blocks = parse_markdown_blocks(input);
+        apply_autolinks(&mut blocks);
+
+        match &blocks[0] {
+            MarkdownBlock::Paragraph { spans, links } => {
+                // Should have 3 spans: "Before ", URL, " After"
+                assert!(spans.len() >= 3, "Should have at least 3 spans after split");
+                assert_eq!(links.len(), 1);
+
+                // Check text reconstruction
+                let combined: String = spans.iter().map(|s| s.text.as_str()).collect();
+                assert_eq!(combined, "Before https://example.com After");
+
+                // Check that only the URL span has link_url
+                let link_spans: Vec<_> = spans.iter().filter(|s| s.link_url.is_some()).collect();
+                assert_eq!(link_spans.len(), 1);
+                assert_eq!(link_spans[0].text, "https://example.com");
+            }
+            _ => panic!("Expected Paragraph"),
+        }
+    }
+}

--- a/src/ui_gpui/components/markdown_content/markdown_parser.rs
+++ b/src/ui_gpui/components/markdown_content/markdown_parser.rs
@@ -11,8 +11,8 @@
 )]
 
 use super::{
-    count_bytes_in_spans, create_inline_span, extract_language, strip_html_tags, Alignment,
-    InlineStyle, MarkdownBlock, MarkdownInline, TableCell,
+    apply_autolinks, count_bytes_in_spans, create_inline_span, extract_language, strip_html_tags,
+    Alignment, InlineStyle, MarkdownBlock, MarkdownInline, TableCell,
 };
 use std::ops::Range;
 
@@ -25,26 +25,30 @@ use std::ops::Range;
 /// @requirement:REQ-MD-PARSE-001
 /// @pseudocode parse-markdown-blocks.md lines 1-10
 pub(crate) fn parse_markdown_blocks(content: &str) -> Vec<MarkdownBlock> {
-    let parsed = ParseState::new().parse(content);
+    let mut parsed = ParseState::new().parse(content);
     if parsed
         .iter()
         .any(|block| matches!(block, MarkdownBlock::Table { .. }))
     {
+        apply_autolinks(&mut parsed);
         return parsed;
     }
 
     let normalized = normalize_imperfect_table_markdown(content);
     if matches!(normalized, std::borrow::Cow::Borrowed(_)) {
+        apply_autolinks(&mut parsed);
         return parsed;
     }
 
-    let reparsed = ParseState::new().parse(normalized.as_ref());
+    let mut reparsed = ParseState::new().parse(normalized.as_ref());
     if reparsed
         .iter()
         .any(|block| matches!(block, MarkdownBlock::Table { .. }))
     {
+        apply_autolinks(&mut reparsed);
         reparsed
     } else {
+        apply_autolinks(&mut parsed);
         parsed
     }
 }

--- a/src/ui_gpui/views/chat_view/render.rs
+++ b/src/ui_gpui/views/chat_view/render.rs
@@ -10,6 +10,9 @@ use super::state::{ApprovalBubbleState, ChatMessage, MessageRole, StreamingState
 use super::ChatView;
 use crate::events::types::{ToolApprovalResponseAction, UserEvent};
 use crate::presentation::view_command::AppMode;
+use crate::ui_gpui::components::markdown_content::{
+    blocks_to_elements, parse_markdown_blocks, MarkdownBlock,
+};
 use crate::ui_gpui::components::{ApprovalBubble, AssistantBubble};
 use crate::ui_gpui::theme::Theme;
 use crate::ui_gpui::views::main_panel::MainPanelAppState;
@@ -54,6 +57,34 @@ const fn is_emoji(c: char) -> bool {
         '\u{20E3}'                |  // Combining enclosing keycap
         '\u{E0020}'..='\u{E007F}' // Tags for emoji sequences
     )
+}
+
+/// Check if markdown blocks contain any links.
+///
+/// @plan:PLAN-20260402-ISSUE153.P02
+/// @requirement:REQ-MSG-LINK-002
+fn has_any_links(blocks: &[MarkdownBlock]) -> bool {
+    blocks.iter().any(|block| match block {
+        MarkdownBlock::Paragraph { links, .. } | MarkdownBlock::Heading { links, .. } => {
+            !links.is_empty()
+        }
+        MarkdownBlock::BlockQuote { blocks } => has_any_links(blocks),
+        MarkdownBlock::List { items, .. } => {
+            items.iter().any(|item_blocks| has_any_links(item_blocks))
+        }
+        MarkdownBlock::Table { header, rows, .. } => {
+            let header_has_links = header.iter().any(|cell| {
+                !cell.links.is_empty() || cell.spans.iter().any(|span| span.link_url.is_some())
+            });
+            let body_has_links = rows.iter().any(|row| {
+                row.iter().any(|cell| {
+                    !cell.links.is_empty() || cell.spans.iter().any(|span| span.link_url.is_some())
+                })
+            });
+            header_has_links || body_has_links
+        }
+        _ => false,
+    })
 }
 
 impl ChatView {
@@ -382,28 +413,37 @@ impl ChatView {
     }
 
     /// Render user message - right aligned, green bubble
+    /// @plan:PLAN-20260402-ISSUE153.P02
+    /// @requirement:REQ-MSG-LINK-001
     pub(super) fn render_user_message(content: &str) -> gpui::AnyElement {
-        let content_owned = content.to_string();
+        // Use markdown pipeline for user messages to support clickable links
+        let blocks = parse_markdown_blocks(content);
+        let rendered = blocks_to_elements(&blocks);
+        let has_links = has_any_links(&blocks);
+
+        let raw_content = content.to_string();
+        let mut bubble = div()
+            .max_w(px(300.0))
+            .px(px(10.0))
+            .py(px(10.0))
+            .rounded(px(12.0))
+            .text_size(px(Theme::font_size_mono()))
+            .children(rendered);
+
+        // Only enable click-to-copy when no links are present
+        if !has_links {
+            bubble = bubble
+                .cursor_pointer()
+                .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                    cx.write_to_clipboard(gpui::ClipboardItem::new_string(raw_content.clone()));
+                });
+        }
+
         div()
             .w_full()
             .flex()
             .justify_end()
-            .child({
-                let text = content_owned.clone();
-                Theme::user_bubble(
-                    div()
-                        .max_w(px(300.0))
-                        .px(px(10.0))
-                        .py(px(10.0))
-                        .rounded(px(12.0))
-                        .text_size(px(Theme::font_size_mono()))
-                        .cursor_pointer()
-                        .on_mouse_down(MouseButton::Left, move |_, _, cx| {
-                            cx.write_to_clipboard(gpui::ClipboardItem::new_string(text.clone()));
-                        })
-                        .child(content_owned),
-                )
-            })
+            .child(Theme::user_bubble(bubble))
             .into_any_element()
     }
 

--- a/src/ui_gpui/views/chat_view/render.rs
+++ b/src/ui_gpui/views/chat_view/render.rs
@@ -11,7 +11,7 @@ use super::ChatView;
 use crate::events::types::{ToolApprovalResponseAction, UserEvent};
 use crate::presentation::view_command::AppMode;
 use crate::ui_gpui::components::markdown_content::{
-    blocks_to_elements, parse_markdown_blocks, MarkdownBlock,
+    blocks_to_elements_with_color, parse_markdown_blocks, MarkdownBlock,
 };
 use crate::ui_gpui::components::{ApprovalBubble, AssistantBubble};
 use crate::ui_gpui::theme::Theme;
@@ -418,7 +418,9 @@ impl ChatView {
     pub(super) fn render_user_message(content: &str) -> gpui::AnyElement {
         // Use markdown pipeline for user messages to support clickable links
         let blocks = parse_markdown_blocks(content);
-        let rendered = blocks_to_elements(&blocks);
+        // Use user_bubble_text() for proper contrast on green background
+        let text_color = Theme::user_bubble_text();
+        let rendered = blocks_to_elements_with_color(&blocks, text_color);
         let has_links = has_any_links(&blocks);
 
         let raw_content = content.to_string();


### PR DESCRIPTION
## Summary

This PR implements clickable link support for URLs in chat messages, addressing issue #153.

### Features Implemented

1. **URL Autolink Detection**
   - Detects bare URLs (`https://`, `http://`, and `www.`) in message text
   - Handles trailing punctuation (`.`, `,`, `!`, `?`, `)`, `]`)
   - Normalizes `www.` URLs to `https://www.`
   - Preserves explicit markdown links `[text](url)`

2. **Markdown Pipeline Integration**
   - URL detection runs as a post-processing step on the markdown IR
   - Works for both user and assistant messages
   - Respects code blocks and inline code (URLs in code are NOT linked)

3. **User Message Rendering**
   - Refactored to use the markdown pipeline for consistent link behavior
   - Click-to-copy is now disabled when links are present
   - Links take click precedence over copy behavior

4. **Security**
   - URL scheme validation via existing `is_safe_url()` (only http/https allowed)
   - Links open in external browser via `cx.open_url()`

### Files Changed

- `src/ui_gpui/components/markdown_content/autolink.rs` - New file with URL detection logic
- `src/ui_gpui/components/markdown_content/markdown_parser.rs` - Wired autolink processing
- `src/ui_gpui/components/markdown_content.rs` - Module exports
- `src/ui_gpui/views/chat_view/render.rs` - User message rendering refactor

### Testing

- 20+ unit tests for URL detection edge cases
- Integration tests for markdown pipeline
- Tests verify code spans are excluded from autolinking
- Tests verify explicit links are preserved alongside autolinks

### Acceptance Criteria

- [x] URLs are auto-detected in message text
- [x] Links render with appropriate styling (underlined, accent color)
- [x] Click opens URL in default browser
- [x] Works in both user and assistant messages
- [x] Works with markdown rendering
- [x] Handles edge cases: links in code blocks, trailing punctuation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Bare URLs in messages are now automatically converted to clickable links, with intelligent punctuation trimming and `www.` normalization
* User messages now render with full markdown formatting instead of plain text
* Improved click-to-copy behavior: disabled when messages contain links to preserve link functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->