### PR TITLE
Restore Greenscreen contrast on action surfaces (Fixes #162)

### DIFF
--- a/src/ui_gpui/views/api_key_manager_view/render.rs
+++ b/src/ui_gpui/views/api_key_manager_view/render.rs
@@ -413,8 +413,8 @@ impl ApiKeyManagerView {
                     .rounded(px(4.0))
                     .bg(Theme::accent())
                     .text_size(px(Theme::font_size_mono()))
-                    .text_color(Theme::text_primary())
-                    .hover(|s| s.opacity(0.85))
+                    .text_color(Theme::accent_fg())
+                    .hover(|s| s.bg(Theme::accent_hover()).text_color(Theme::accent_fg()))
                     .child("Save")
                     .on_mouse_down(
                         MouseButton::Left,

--- a/src/ui_gpui/views/history_view.rs
+++ b/src/ui_gpui/views/history_view.rs
@@ -279,7 +279,7 @@ impl HistoryView {
                     .rounded(px(6.0))
                     .bg(Theme::bg_dark())
                     .cursor_pointer()
-                    .hover(|s| s.bg(Theme::accent()))
+                    .hover(|s| s.bg(Theme::accent()).text_color(Theme::accent_fg()))
                     .text_size(px(Theme::font_size_mono()))
                     .text_color(Theme::text_primary())
                     .child("Load")

--- a/src/ui_gpui/views/settings_view/render.rs
+++ b/src/ui_gpui/views/settings_view/render.rs
@@ -563,7 +563,7 @@ impl SettingsView {
                             .items_center()
                             .justify_center()
                             .cursor_pointer()
-                            .hover(|s| s.bg(Theme::accent()))
+                            .hover(|s| s.bg(Theme::accent()).text_color(Theme::accent_fg()))
                             .text_size(px(Theme::font_size_ui()))
                             .text_color(Theme::text_primary())
                             .child("Browse…")

--- a/src/ui_gpui/views/settings_view/render_backup_panel.rs
+++ b/src/ui_gpui/views/settings_view/render_backup_panel.rs
@@ -424,7 +424,9 @@ impl SettingsView {
             .py(px(8.0))
             .rounded(px(4.0))
             .cursor_pointer()
-            .when(!in_progress, |d| d.hover(|s| s.bg(Theme::accent())))
+            .when(!in_progress, |d| {
+                d.hover(|s| s.bg(Theme::accent()).text_color(Theme::accent_fg()))
+            })
             .bg(if in_progress {
                 Theme::bg_dark()
             } else {

--- a/src/ui_gpui/views/settings_view/render_tool_approval.rs
+++ b/src/ui_gpui/views/settings_view/render_tool_approval.rs
@@ -190,7 +190,7 @@ impl SettingsView {
                     .items_center()
                     .justify_center()
                     .cursor_pointer()
-                    .hover(|s| s.bg(Theme::accent()))
+                    .hover(|s| s.bg(Theme::accent()).text_color(Theme::accent_fg()))
                     .text_size(px(Theme::font_size_ui()))
                     .text_color(Theme::text_primary())
                     .child("Add")

--- a/tests/theme_runtime_static_tests.rs
+++ b/tests/theme_runtime_static_tests.rs
@@ -46,7 +46,10 @@ fn approx_eq(a: f32, b: f32) -> bool {
 }
 
 fn colors_differ(a: gpui::Hsla, b: gpui::Hsla) -> bool {
-    !approx_eq(a.h, b.h) || !approx_eq(a.s, b.s) || !approx_eq(a.l, b.l)
+    !approx_eq(a.h, b.h)
+        || !approx_eq(a.s, b.s)
+        || !approx_eq(a.l, b.l)
+        || !approx_eq(a.a, b.a)
 }
 
 // ── existing baseline test (kept intact) ────────────────────────────────────
@@ -346,14 +349,10 @@ fn green_screen_affirmative_and_selected_foregrounds_stay_distinct() {
 #[test]
 fn green_screen_selected_and_affirmative_foregrounds_are_black() -> TestResult {
     let _guard = ThemeSwitchGuard::acquire();
-    let catalog = ThemeCatalog::load_bundled()?;
-    let green = catalog
-        .get("green-screen")
-        .expect("green-screen must exist");
 
     set_active_theme_slug("green-screen");
 
-    let expected_selection_fg = Theme::hex_to_hsla(&green.colors.selection.fg)?;
+    let expected_black = Theme::hex_to_hsla("#000000")?;
 
     for (label, actual) in [
         ("selection_fg", Theme::selection_fg()),
@@ -362,10 +361,11 @@ fn green_screen_selected_and_affirmative_foregrounds_are_black() -> TestResult {
         ("user_bubble_text", Theme::user_bubble_text()),
     ] {
         assert!(
-            approx_eq(actual.h, expected_selection_fg.h)
-                && approx_eq(actual.s, expected_selection_fg.s)
-                && approx_eq(actual.l, expected_selection_fg.l),
-            "{label} must resolve to the green-screen selection foreground"
+            approx_eq(actual.h, expected_black.h)
+                && approx_eq(actual.s, expected_black.s)
+                && approx_eq(actual.l, expected_black.l)
+                && approx_eq(actual.a, expected_black.a),
+            "{label} must resolve to black in the green-screen theme"
         );
     }
 

--- a/tests/theme_runtime_static_tests.rs
+++ b/tests/theme_runtime_static_tests.rs
@@ -46,10 +46,7 @@ fn approx_eq(a: f32, b: f32) -> bool {
 }
 
 fn colors_differ(a: gpui::Hsla, b: gpui::Hsla) -> bool {
-    !approx_eq(a.h, b.h)
-        || !approx_eq(a.s, b.s)
-        || !approx_eq(a.l, b.l)
-        || !approx_eq(a.a, b.a)
+    !approx_eq(a.h, b.h) || !approx_eq(a.s, b.s) || !approx_eq(a.l, b.l) || !approx_eq(a.a, b.a)
 }
 
 // ── existing baseline test (kept intact) ────────────────────────────────────

--- a/tests/theme_runtime_static_tests.rs
+++ b/tests/theme_runtime_static_tests.rs
@@ -45,6 +45,10 @@ fn approx_eq(a: f32, b: f32) -> bool {
     (a - b).abs() < 1e-5
 }
 
+fn colors_differ(a: gpui::Hsla, b: gpui::Hsla) -> bool {
+    !approx_eq(a.h, b.h) || !approx_eq(a.s, b.s) || !approx_eq(a.l, b.l)
+}
+
 // ── existing baseline test (kept intact) ────────────────────────────────────
 
 #[test]
@@ -315,6 +319,55 @@ fn green_screen_accent_error_is_file_driven() -> TestResult {
         from_theme.l,
         from_file.l
     );
+
+    Ok(())
+}
+
+#[test]
+fn green_screen_affirmative_and_selected_foregrounds_stay_distinct() {
+    let _guard = ThemeSwitchGuard::acquire();
+
+    set_active_theme_slug("green-screen");
+
+    assert!(
+        colors_differ(Theme::selection_bg(), Theme::selection_fg()),
+        "selection foreground must differ from selection background in green-screen"
+    );
+    assert!(
+        colors_differ(Theme::accent(), Theme::accent_fg()),
+        "accent foreground must differ from accent background in green-screen"
+    );
+    assert!(
+        colors_differ(Theme::success(), Theme::selection_fg()),
+        "success status color should remain visually distinct from selected foreground in green-screen"
+    );
+}
+
+#[test]
+fn green_screen_selected_and_affirmative_foregrounds_are_black() -> TestResult {
+    let _guard = ThemeSwitchGuard::acquire();
+    let catalog = ThemeCatalog::load_bundled()?;
+    let green = catalog
+        .get("green-screen")
+        .expect("green-screen must exist");
+
+    set_active_theme_slug("green-screen");
+
+    let expected_selection_fg = Theme::hex_to_hsla(&green.colors.selection.fg)?;
+
+    for (label, actual) in [
+        ("selection_fg", Theme::selection_fg()),
+        ("accent_fg", Theme::accent_fg()),
+        ("error_fg", Theme::error_fg()),
+        ("user_bubble_text", Theme::user_bubble_text()),
+    ] {
+        assert!(
+            approx_eq(actual.h, expected_selection_fg.h)
+                && approx_eq(actual.s, expected_selection_fg.s)
+                && approx_eq(actual.l, expected_selection_fg.l),
+            "{label} must resolve to the green-screen selection foreground"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- restore Greenscreen-safe foregrounds for accent-backed Save and hover action controls
- keep action hovers readable by switching to the high-contrast accent foreground when the background turns green
- add Greenscreen theme regression tests covering selected and affirmative foreground/background pairings

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --test theme_runtime_static_tests
- cargo check --lib
- cargo test --lib --tests (captured log showed passing suites before environment termination)
- lizard -C 50 -L 100 src tests
- scoped file-length check for src/ and tests/ (only pre-existing oversized test files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated button hover styles across the app so accent-themed buttons consistently apply accent foreground text color alongside accent backgrounds (improves visual consistency for Save, Load, Browse…, Back Up Now, Add and similar actions).

* **Tests**
  * Added runtime theme tests validating color distinctness and exact foreground mappings for the green-screen theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->