### PR TITLE
Popout: load transcript after delete-and-auto-select (Fixes #178)

### DIFF
--- a/src/main_gpui.rs
+++ b/src/main_gpui.rs
@@ -256,6 +256,33 @@ fn spawn_broadcast_to_mpsc_view_command_bridge(
 // Runtime bridge pump + helpers
 // ============================================================================
 
+/// Emit `UserEvent::SelectConversation` for `(id, generation)` and, if the
+/// transport is full, record a `ConversationLoadFailed` against the same
+/// generation so the presenter does not get stuck in `Loading` forever.
+///
+/// Shared by both manual selection (`handle_select_conversation_intent`) and
+/// reducer-produced auto-selection fed through the runtime pump
+/// (`reduce_batch_with_result().pending_selection`, added for Issue #178).
+fn emit_select_or_record_failure(
+    app_state: &AppState,
+    conversation_id: uuid::Uuid,
+    selection_generation: u64,
+) {
+    let sent = app_state.gpui_bridge.emit(UserEvent::SelectConversation {
+        id: conversation_id,
+        selection_generation,
+    });
+    if !sent {
+        app_state
+            .app_store
+            .reduce_batch(vec![ViewCommand::ConversationLoadFailed {
+                conversation_id,
+                selection_generation,
+                message: "SelectConversation transport enqueue failed".to_string(),
+            }]);
+    }
+}
+
 /// @plan PLAN-20260304-GPUIREMEDIATE.P05
 /// @requirement REQ-ARCH-003.6
 /// @pseudocode analysis/pseudocode/02-selection-loading-protocol.md:004-014
@@ -266,19 +293,7 @@ fn handle_select_conversation_intent(app_state: &AppState, conversation_id: uuid
     {
         BeginSelectionResult::NoOpSameSelection => {}
         BeginSelectionResult::BeganSelection { generation } => {
-            let sent = app_state.gpui_bridge.emit(UserEvent::SelectConversation {
-                id: conversation_id,
-                selection_generation: generation,
-            });
-            if !sent {
-                app_state
-                    .app_store
-                    .reduce_batch(vec![ViewCommand::ConversationLoadFailed {
-                        conversation_id,
-                        selection_generation: generation,
-                        message: "SelectConversation transport enqueue failed".to_string(),
-                    }]);
-            }
+            emit_select_or_record_failure(app_state, conversation_id, generation);
         }
     }
 }
@@ -349,19 +364,7 @@ fn spawn_runtime_bridge_pump(app_state: AppState, cx: &mut App) {
         // new selection but the chat view stays empty.
         let reduce_result = app_state.app_store.reduce_batch_with_result(commands);
         if let Some((id, selection_generation)) = reduce_result.pending_selection {
-            let sent = app_state.gpui_bridge.emit(UserEvent::SelectConversation {
-                id,
-                selection_generation,
-            });
-            if !sent {
-                app_state
-                    .app_store
-                    .reduce_batch(vec![ViewCommand::ConversationLoadFailed {
-                        conversation_id: id,
-                        selection_generation,
-                        message: "SelectConversation transport enqueue failed".to_string(),
-                    }]);
-            }
+            emit_select_or_record_failure(&app_state, id, selection_generation);
         }
         forward_runtime_commands_to_main_panel(non_store_commands, cx);
         if toggle_window_mode_count % 2 == 1 {

--- a/src/main_gpui.rs
+++ b/src/main_gpui.rs
@@ -341,7 +341,28 @@ fn spawn_runtime_bridge_pump(app_state: AppState, cx: &mut App) {
             }
             non_store_commands.push(cmd.clone());
         }
-        let _changed = app_state.app_store.reduce_batch(commands);
+        // Fixes Issue #178: when the reducer auto-selects a successor
+        // conversation (e.g. after a delete) it records the pending selection
+        // in the `BatchReduceResult`. Emit the corresponding
+        // `UserEvent::SelectConversation` so the presenter loads the
+        // replacement transcript — without this, the sidebar shows the
+        // new selection but the chat view stays empty.
+        let reduce_result = app_state.app_store.reduce_batch_with_result(commands);
+        if let Some((id, selection_generation)) = reduce_result.pending_selection {
+            let sent = app_state.gpui_bridge.emit(UserEvent::SelectConversation {
+                id,
+                selection_generation,
+            });
+            if !sent {
+                app_state
+                    .app_store
+                    .reduce_batch(vec![ViewCommand::ConversationLoadFailed {
+                        conversation_id: id,
+                        selection_generation,
+                        message: "SelectConversation transport enqueue failed".to_string(),
+                    }]);
+            }
+        }
         forward_runtime_commands_to_main_panel(non_store_commands, cx);
         if toggle_window_mode_count % 2 == 1 {
             let _ = cx.update_global::<SystemTray, _>(|tray, cx| {

--- a/src/ui_gpui/app_store.rs
+++ b/src/ui_gpui/app_store.rs
@@ -285,7 +285,29 @@ impl GpuiAppStore {
     ///
     /// Panics if the store mutex is poisoned.
     pub fn reduce_batch(&self, commands: Vec<ViewCommand>) -> bool {
-        self.reduce_batch_with_result(commands).changed
+        let result = self.reduce_batch_with_result(commands);
+        // If a future caller feeds a `ConversationDeleted` for the currently
+        // selected conversation through this compatibility wrapper, the
+        // reducer will auto-select a successor (snapshot moves to
+        // `Loading`) but the pending `UserEvent::SelectConversation` would
+        // be dropped here — reintroducing the Issue #178 symptom from a
+        // different caller. Today only `spawn_runtime_bridge_pump` reaches
+        // the delete path and it uses `reduce_batch_with_result`, so this
+        // is purely a forward-looking guard.
+        debug_assert!(
+            result.pending_selection.is_none(),
+            "reduce_batch dropped a pending SelectConversation event; callers that can \
+             produce ConversationDeleted must use reduce_batch_with_result (Issue #178)"
+        );
+        if let Some((id, generation)) = result.pending_selection {
+            tracing::warn!(
+                conversation_id = %id,
+                selection_generation = generation,
+                "reduce_batch dropped pending SelectConversation event; \
+                 callers producing ConversationDeleted must use reduce_batch_with_result"
+            );
+        }
+        result.changed
     }
 
     /// Reduce a batch and return the rich `BatchReduceResult`, including any

--- a/src/ui_gpui/app_store.rs
+++ b/src/ui_gpui/app_store.rs
@@ -132,6 +132,29 @@ pub(super) struct AppStoreInner {
     pub(super) subscribers: Vec<flume::Sender<GpuiAppSnapshot>>,
     pub(super) title_provenance: SelectedTitleProvenance,
     pub(super) finalized_stream_guards: HashMap<Uuid, FinalizedStreamGuard>,
+    /// Pending conversation-selection event produced by the reducer that must
+    /// be surfaced to the runtime pump so the presenter can load the
+    /// replacement transcript. Populated by `reduce_conversation_deleted` when
+    /// it auto-selects a successor via `BatchNoPublish` `begin_selection`.
+    ///
+    /// Fixes: Issue #178 — delete-and-auto-select left the chat view empty
+    /// because the snapshot changed but no `UserEvent::SelectConversation`
+    /// was ever emitted.
+    pub(super) pending_selection_event: Option<(Uuid, u64)>,
+}
+
+/// Result of reducing a batch of runtime commands.
+///
+/// `changed` preserves the historical boolean indicating whether the snapshot
+/// mutated. `pending_selection` surfaces any auto-selection (e.g. after a
+/// delete) that still needs a `UserEvent::SelectConversation` emitted by the
+/// runtime pump to trigger transcript loading.
+///
+/// Fixes: Issue #178.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BatchReduceResult {
+    pub changed: bool,
+    pub pending_selection: Option<(Uuid, u64)>,
 }
 
 /// Process-lifetime authoritative store handle.
@@ -262,19 +285,41 @@ impl GpuiAppStore {
     ///
     /// Panics if the store mutex is poisoned.
     pub fn reduce_batch(&self, commands: Vec<ViewCommand>) -> bool {
+        self.reduce_batch_with_result(commands).changed
+    }
+
+    /// Reduce a batch and return the rich `BatchReduceResult`, including any
+    /// pending selection event the runtime pump must emit.
+    ///
+    /// Fixes Issue #178: auto-selection after a delete needs to surface a
+    /// `UserEvent::SelectConversation` so the presenter loads the new
+    /// transcript. Callers that need to observe those pending selections
+    /// (notably `spawn_runtime_bridge_pump`) should prefer this method over
+    /// `reduce_batch`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the store mutex is poisoned.
+    pub fn reduce_batch_with_result(&self, commands: Vec<ViewCommand>) -> BatchReduceResult {
         if commands.is_empty() {
-            return false;
+            return BatchReduceResult::default();
         }
 
-        let mut inner = self.inner.lock().expect("gpui app store mutex poisoned");
-        let mut changed = false;
-        for command in commands {
-            changed = reduce_view_command_without_publish(&mut inner, command) || changed;
+        let (changed, pending_selection) = {
+            let mut inner = self.inner.lock().expect("gpui app store mutex poisoned");
+            let mut changed = false;
+            for command in commands {
+                changed = reduce_view_command_without_publish(&mut inner, command) || changed;
+            }
+            if changed {
+                bump_revision_and_publish(&mut inner);
+            }
+            (changed, inner.pending_selection_event.take())
+        };
+        BatchReduceResult {
+            changed,
+            pending_selection,
         }
-        if changed {
-            bump_revision_and_publish(&mut inner);
-        }
-        changed
     }
 
     /// @plan PLAN-20260304-GPUIREMEDIATE.P05
@@ -755,7 +800,15 @@ fn reduce_conversation_deleted(inner: &mut AppStoreInner, id: Uuid) -> bool {
             // incremented generation and initiate a transcript load, matching
             // the behaviour of a user-driven selection change.
             if let Some(next) = next_selected {
-                begin_selection_locked(inner, next, BeginSelectionMode::BatchNoPublish);
+                // Fixes Issue #178: record the pending selection so the
+                // runtime pump emits a `UserEvent::SelectConversation`. The
+                // snapshot update alone is not enough — the presenter's
+                // transcript-loading path is driven by that user event.
+                if let BeginSelectionResult::BeganSelection { generation } =
+                    begin_selection_locked(inner, next, BeginSelectionMode::BatchNoPublish)
+                {
+                    inner.pending_selection_event = Some((next, generation));
+                }
             } else {
                 selection_helpers::reset_selection_to_idle_after_deletion(inner);
             }

--- a/src/ui_gpui/app_store/tests.rs
+++ b/src/ui_gpui/app_store/tests.rs
@@ -277,9 +277,14 @@ fn deleting_selected_conversation_resets_transcript_and_load_state() {
     );
     assert_eq!(before_delete.chat.transcript.len(), 1);
 
-    assert!(store.reduce_batch(vec![ViewCommand::ConversationDeleted {
+    // Use the rich reducer entry point because deleting the selected
+    // conversation triggers an auto-selection that surfaces a pending
+    // `SelectConversation` event — `reduce_batch` intentionally debug-
+    // asserts when callers drop that event (see Issue #178 guard).
+    let delete_result = store.reduce_batch_with_result(vec![ViewCommand::ConversationDeleted {
         id: conversation_a,
-    }]));
+    }]);
+    assert!(delete_result.changed);
 
     let after_delete = store.current_snapshot();
     assert_eq!(

--- a/tests/app_store_tests.rs
+++ b/tests/app_store_tests.rs
@@ -1105,13 +1105,20 @@ mod reduce_batch_conversation_lifecycle {
         });
         begin_and_ready(&store, first, vec![make_message(MessageRole::User, "keep")]);
 
-        assert!(store.reduce_batch(vec![ViewCommand::ConversationDeleted { id: first }]));
+        // Deleting the selected conversation produces a pending
+        // `SelectConversation` event (Issue #178). Use the rich reducer
+        // entry point so the compat wrapper's debug-assert does not fire.
+        let first_delete =
+            store.reduce_batch_with_result(vec![ViewCommand::ConversationDeleted { id: first }]);
+        assert!(first_delete.changed);
         let snapshot = current_snapshot(&store);
         assert_eq!(snapshot.chat.selected_conversation_id, Some(second));
         assert_eq!(snapshot.history.selected_conversation_id, Some(second));
         assert_eq!(snapshot.chat.selected_conversation_title, "Second");
 
-        assert!(store.reduce_batch(vec![ViewCommand::ConversationDeleted { id: second }]));
+        let second_delete =
+            store.reduce_batch_with_result(vec![ViewCommand::ConversationDeleted { id: second }]);
+        assert!(second_delete.changed);
         let empty_snapshot = current_snapshot(&store);
         assert_eq!(empty_snapshot.chat.selected_conversation_id, None);
         assert_eq!(empty_snapshot.history.selected_conversation_id, None);
@@ -1268,6 +1275,94 @@ mod reduce_batch_conversation_lifecycle {
         let snapshot = current_snapshot(&store);
         assert_eq!(snapshot.chat.selected_conversation_id, None);
         assert_eq!(snapshot.chat.load_state, ConversationLoadState::Idle);
+    }
+
+    /// Regression for Issue #178: `pending_selection_event` is a one-shot
+    /// signal consumed by `reduce_batch_with_result`. A subsequent batch
+    /// must return `pending_selection = None` so the runtime pump does not
+    /// re-emit a stale `SelectConversation` event after the presenter
+    /// already picked it up.
+    #[test]
+    fn pending_selection_event_is_one_shot_per_batch() {
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let store = GpuiAppStore::from_startup_inputs(StartupInputs {
+            profiles: Vec::new(),
+            selected_profile_id: None,
+            conversations: vec![
+                make_summary(first, "First", 0),
+                make_summary(second, "Second", 0),
+            ],
+            selected_conversation: None,
+        });
+        begin_and_ready(&store, first, Vec::new());
+
+        let first_result =
+            store.reduce_batch_with_result(vec![ViewCommand::ConversationDeleted { id: first }]);
+        assert!(
+            first_result.pending_selection.is_some(),
+            "first batch must surface the pending selection"
+        );
+
+        // A follow-up batch that does not touch selection must not replay the
+        // already-consumed pending selection.
+        let follow_up = store.reduce_batch_with_result(vec![ViewCommand::ConversationRenamed {
+            id: second,
+            new_title: "Renamed".to_string(),
+        }]);
+        assert!(
+            follow_up.pending_selection.is_none(),
+            "pending_selection_event must be consumed after the first reduce_batch_with_result call"
+        );
+    }
+
+    /// Regression for Issue #178: when a batch mixes `ConversationDeleted`
+    /// with other commands, the pending selection must still reflect the
+    /// auto-selected successor and not be overwritten or cleared by the
+    /// later non-deleting reducers.
+    #[test]
+    fn pending_selection_survives_additional_commands_in_same_batch() {
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let store = GpuiAppStore::from_startup_inputs(StartupInputs {
+            profiles: Vec::new(),
+            selected_profile_id: None,
+            conversations: vec![
+                make_summary(first, "First", 0),
+                make_summary(second, "Second", 0),
+            ],
+            selected_conversation: None,
+        });
+        begin_and_ready(&store, first, Vec::new());
+
+        let result = store.reduce_batch_with_result(vec![
+            ViewCommand::ConversationDeleted { id: first },
+            ViewCommand::ConversationRenamed {
+                id: second,
+                new_title: "Renamed Successor".to_string(),
+            },
+        ]);
+
+        let (pending_id, pending_generation) = result
+            .pending_selection
+            .expect("deleted-selected batch must still surface pending selection");
+        assert_eq!(pending_id, second);
+        let snapshot = current_snapshot(&store);
+        assert_eq!(snapshot.chat.selected_conversation_id, Some(second));
+        match snapshot.chat.load_state {
+            ConversationLoadState::Loading {
+                conversation_id,
+                generation,
+            } => {
+                assert_eq!(conversation_id, second);
+                assert_eq!(generation, pending_generation);
+            }
+            other => panic!("successor must still be Loading, got {other:?}"),
+        }
+        assert_eq!(
+            snapshot.chat.selected_conversation_title, "Renamed Successor",
+            "subsequent rename in the same batch must still apply to the successor"
+        );
     }
 
     #[test]

--- a/tests/app_store_tests.rs
+++ b/tests/app_store_tests.rs
@@ -1160,6 +1160,116 @@ mod reduce_batch_conversation_lifecycle {
         assert_eq!(snapshot.history.conversations[0].id, selected);
     }
 
+    /// Regression for Issue #178: deleting the selected conversation must
+    /// surface a pending `SelectConversation` event so the runtime pump can
+    /// trigger transcript loading for the auto-selected successor.
+    #[test]
+    fn deleting_selected_conversation_produces_pending_selection_event() {
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let store = GpuiAppStore::from_startup_inputs(StartupInputs {
+            profiles: Vec::new(),
+            selected_profile_id: None,
+            conversations: vec![
+                make_summary(first, "First", 0),
+                make_summary(second, "Second", 0),
+            ],
+            selected_conversation: None,
+        });
+        begin_and_ready(&store, first, vec![make_message(MessageRole::User, "keep")]);
+
+        let result =
+            store.reduce_batch_with_result(vec![ViewCommand::ConversationDeleted { id: first }]);
+
+        assert!(result.changed, "deletion must mark snapshot as changed");
+        let (pending_id, pending_generation) = result
+            .pending_selection
+            .expect("deleting selected conversation must produce pending selection event");
+        assert_eq!(
+            pending_id, second,
+            "pending selection must target the auto-selected successor"
+        );
+
+        let snapshot = current_snapshot(&store);
+        assert_eq!(snapshot.chat.selected_conversation_id, Some(second));
+        match snapshot.chat.load_state {
+            ConversationLoadState::Loading {
+                conversation_id,
+                generation,
+            } => {
+                assert_eq!(conversation_id, second);
+                assert_eq!(
+                    generation, pending_generation,
+                    "pending selection generation must match the snapshot Loading generation"
+                );
+                assert_eq!(generation, snapshot.chat.selection_generation);
+            }
+            other => panic!("auto-selected successor must enter Loading state, got {other:?}"),
+        }
+    }
+
+    /// Regression for Issue #178: deleting a non-selected conversation must
+    /// not produce a pending selection event — the selected conversation and
+    /// its transcript remain untouched.
+    #[test]
+    fn deleting_non_selected_conversation_produces_no_pending_selection() {
+        let selected = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let store = GpuiAppStore::from_startup_inputs(StartupInputs {
+            profiles: Vec::new(),
+            selected_profile_id: None,
+            conversations: vec![
+                make_summary(selected, "Selected", 0),
+                make_summary(other, "Other", 0),
+            ],
+            selected_conversation: None,
+        });
+        begin_and_ready(
+            &store,
+            selected,
+            vec![make_message(MessageRole::User, "keep")],
+        );
+
+        let result =
+            store.reduce_batch_with_result(vec![ViewCommand::ConversationDeleted { id: other }]);
+
+        assert!(result.changed);
+        assert!(
+            result.pending_selection.is_none(),
+            "deleting a non-selected conversation must not produce a pending selection event"
+        );
+
+        let snapshot = current_snapshot(&store);
+        assert_eq!(snapshot.chat.selected_conversation_id, Some(selected));
+        assert_eq!(
+            snapshot.chat.transcript,
+            vec![make_message(MessageRole::User, "keep")],
+            "the selected conversation's transcript must remain intact"
+        );
+    }
+
+    /// Regression for Issue #178: deleting the only conversation leaves the
+    /// snapshot idle and must not produce a spurious pending selection event
+    /// (there is no successor to load).
+    #[test]
+    fn deleting_last_conversation_produces_no_pending_selection() {
+        let only = Uuid::new_v4();
+        let store = make_store_with_conversation(only, "Only");
+        begin_and_ready(&store, only, vec![make_message(MessageRole::User, "msg")]);
+
+        let result =
+            store.reduce_batch_with_result(vec![ViewCommand::ConversationDeleted { id: only }]);
+
+        assert!(result.changed);
+        assert!(
+            result.pending_selection.is_none(),
+            "deleting the last conversation must not produce a pending selection event"
+        );
+        let snapshot = current_snapshot(&store);
+        assert_eq!(snapshot.chat.selected_conversation_id, None);
+        assert_eq!(snapshot.chat.load_state, ConversationLoadState::Idle);
+    }
+
     #[test]
     fn conversation_renamed_updates_history_chat_and_selected_title() {
         let id = Uuid::new_v4();


### PR DESCRIPTION
## Summary

Fixes Issue #178: in popout mode, deleting the selected conversation
visibly selects the next conversation in the sidebar, but the main chat
view stays on the "no messages" empty state. Clicking the highlighted
row manually loads the conversation correctly — only the
delete-and-auto-select path is broken.

## Root cause

When the selected conversation is deleted, `reduce_conversation_deleted`
calls `begin_selection_locked(..., BatchNoPublish)`, which updates the
snapshot (sidebar highlight, `ConversationLoadState::Loading`, bumped
`selection_generation`) **but never emits
`UserEvent::SelectConversation`**. The presenter's transcript-loading
path (`ChatPresenter::handle_select_conversation` →
`replay_conversation_messages`) is driven entirely by that user event,
so the chat view is left with no transcript to render. Manual clicks go
through `handle_select_conversation_intent`, which explicitly emits the
event — that's why manual selection works.

## Fix

Thread the pending selection out of the reducer and have the runtime
pump emit the `SelectConversation` event so the existing presenter flow
loads the transcript. No new selection protocol, no duplicate paths.

- Add `BatchReduceResult { changed, pending_selection }` and a new
  `GpuiAppStore::reduce_batch_with_result` that returns it. The
  existing `reduce_batch() -> bool` becomes a thin compatibility
  wrapper so the many test call sites don't need to change.
- Track the auto-selection inside
  `AppStoreInner::pending_selection_event` from
  `reduce_conversation_deleted` (only for the `SelectedDeleted` outcome
  with a successor). The field is cleared on every batch boundary so
  one auto-selection produces exactly one event.
- In `spawn_runtime_bridge_pump`, call `reduce_batch_with_result` and,
  when `pending_selection` is `Some`, emit
  `UserEvent::SelectConversation { id, selection_generation }` — the
  same contract manual clicks use. If transport enqueue fails, fall
  back to recording a `ConversationLoadFailed` for that generation so
  the chat view surfaces the failure instead of silently hanging.

## Tests

New regression tests in `tests/app_store_tests.rs`:

- `deleting_selected_conversation_produces_pending_selection_event` —
  deleting the selected conversation returns
  `pending_selection = Some((successor, loading_generation))` and the
  snapshot enters `Loading` for the successor with the matching
  generation.
- `deleting_non_selected_conversation_produces_no_pending_selection` —
  deleting a non-selected conversation returns `None` and leaves the
  selected conversation's transcript intact.
- `deleting_last_conversation_produces_no_pending_selection` —
  deleting the only conversation returns `None` and lands on
  `ConversationLoadState::Idle`.

Full verification run locally: `cargo fmt --all -- --check`,
`cargo clippy --all-targets -- -D warnings`,
`cargo test --lib --tests`, `cargo xtask guard` — all clean.

## Acceptance criteria

- [x] In popout mode, deleting a conversation loads the newly-highlighted
  conversation's messages automatically.
- [x] If the deleted conversation was the only one, the empty state
  remains correct (`Idle`, no pending event).
- [x] Behaviour is consistent between popout mode and the menu-bar
  popover — the fix lives in the shared store/pump, not in any
  view-specific code.
- [x] Regression tests cover the delete-and-auto-select flow.

Fixes #178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic successor conversation selection now reliably triggers loading of the replacement transcript after deleting the selected conversation, preventing the UI from waiting indefinitely.
  * Improved fallback handling when loading the auto-selected conversation fails.

* **Chores**
  * Added regression tests covering conversation-deletion and auto-selection edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->