### PR TITLE
Profile Editor: fix Save-disabled-after-Browse and stale new-profile form (Fixes #182)

### DIFF
--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -198,6 +198,16 @@ pub enum UserEvent {
     /// @plan PLAN-20250130-GPUIREDUX.P08
     SaveProfileEditor,
 
+    /// User initiated the "create new profile" flow.
+    ///
+    /// Emitted by the `+` button and `Shift+=` shortcut in Settings.
+    /// The presenter responds with [`crate::presentation::ViewCommand::ProfileEditorReset`]
+    /// so the editor view drops any stale state from a prior edit or Browse flow.
+    ///
+    /// Fixes profile editor state-management bugs where the new-profile form
+    /// was pre-populated with a previously-edited profile's fields.
+    OpenNewProfile,
+
     /// Store a new API key in the OS keychain.
     StoreApiKey { label: String, value: String },
 
@@ -324,16 +334,6 @@ pub enum UserEvent {
 
     /// User clicked back
     NavigateBack,
-
-    /// User initiated the "create new profile" flow.
-    ///
-    /// Emitted by the `+` button and `Shift+=` shortcut in Settings.
-    /// The presenter responds with [`crate::presentation::ViewCommand::ProfileEditorReset`]
-    /// so the editor view drops any stale state from a prior edit or Browse flow.
-    ///
-    /// Fixes profile editor state-management bugs where the new-profile form
-    /// was pre-populated with a previously-edited profile's fields.
-    OpenNewProfile,
 }
 
 /// Actions a user can take on a tool approval request.

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -324,6 +324,16 @@ pub enum UserEvent {
 
     /// User clicked back
     NavigateBack,
+
+    /// User initiated the "create new profile" flow.
+    ///
+    /// Emitted by the `+` button and `Shift+=` shortcut in Settings.
+    /// The presenter responds with [`crate::presentation::ViewCommand::ProfileEditorReset`]
+    /// so the editor view drops any stale state from a prior edit or Browse flow.
+    ///
+    /// Fixes profile editor state-management bugs where the new-profile form
+    /// was pre-populated with a previously-edited profile's fields.
+    OpenNewProfile,
 }
 
 /// Actions a user can take on a tool approval request.

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -650,6 +650,14 @@ pub struct ModelProfileParameters {
     pub show_thinking: Option<bool>,
     pub enable_thinking: Option<bool>,
     pub thinking_budget: Option<u32>,
+    /// Context window size (the editor field labeled "CONTEXT LIMIT").
+    ///
+    /// Lives at the profile level on disk
+    /// ([`crate::models::ModelProfile::context_window_size`]) but is carried
+    /// through the GPUI save payload here so the presenter can persist edits
+    /// alongside the rest of the parameters. `None` means "leave the existing
+    /// value untouched" (issue #182).
+    pub context_window_size: Option<usize>,
 }
 
 /// Placeholder for `ModelProfile`

--- a/src/presentation/profile_editor_presenter.rs
+++ b/src/presentation/profile_editor_presenter.rs
@@ -206,6 +206,11 @@ impl ProfileEditorPresenter {
                 Self::on_save_profile(profile_service, event_bus_tx, view_tx, *profile).await;
             }
 
+            UserEvent::OpenNewProfile => {
+                tracing::info!("ProfileEditorPresenter: resetting editor for new-profile flow");
+                let _ = view_tx.send(ViewCommand::ProfileEditorReset);
+            }
+
             UserEvent::SaveProfileEditor => {
                 Self::on_save_profile_editor(
                     profile_service,

--- a/src/presentation/profile_editor_presenter.rs
+++ b/src/presentation/profile_editor_presenter.rs
@@ -246,13 +246,57 @@ impl ProfileEditorPresenter {
 
         let auth = Self::profile_auth_from_payload(&profile);
         let parameters = Self::profile_parameters_from_payload(&profile);
+        // The "CONTEXT LIMIT" editor field lives on `ModelProfile` itself,
+        // not inside `ModelParameters`, so we extract it before the payload
+        // gets moved into `persist_profile_from_payload`. Issue #182.
+        let payload_context_window = profile
+            .parameters
+            .as_ref()
+            .and_then(|p| p.context_window_size);
         let updated =
             Self::update_profile_from_payload(profile_service, &profile, &auth, &parameters).await;
         let persisted =
             Self::persist_profile_from_payload(updated, profile_service, profile, auth, parameters)
                 .await;
+        let persisted =
+            Self::apply_context_window_size(profile_service, persisted, payload_context_window)
+                .await;
 
         Self::publish_profile_save_result(event_bus_tx, view_tx, persisted).await;
+    }
+
+    /// Persist a `context_window_size` change separately from `update`.
+    ///
+    /// `ProfileService::update` does not take `context_window_size` (it lives
+    /// on the profile itself, not inside `ModelParameters`), so once the
+    /// rest of the profile is saved we issue a follow-up
+    /// [`ProfileService::set_context_window_size`] when the payload carried
+    /// a value and it differs from what is already persisted. Issue #182.
+    async fn apply_context_window_size(
+        profile_service: &Arc<dyn ProfileService>,
+        persisted: Result<crate::models::ModelProfile, ServiceError>,
+        payload_context_window: Option<usize>,
+    ) -> Result<crate::models::ModelProfile, ServiceError> {
+        let saved = persisted?;
+        let Some(size) = payload_context_window else {
+            return Ok(saved);
+        };
+        if saved.context_window_size == size {
+            return Ok(saved);
+        }
+        if let Err(e) = profile_service
+            .set_context_window_size(saved.id, size)
+            .await
+        {
+            tracing::error!(
+                "Failed to persist context_window_size={size} for profile {}: {e}",
+                saved.id
+            );
+            return Err(e);
+        }
+        let mut updated = saved;
+        updated.context_window_size = size;
+        Ok(updated)
     }
 
     fn profile_auth_from_payload(profile: &crate::events::types::ModelProfile) -> AuthConfig {

--- a/src/presentation/settings_presenter_mcp.rs
+++ b/src/presentation/settings_presenter_mcp.rs
@@ -276,7 +276,12 @@ impl SettingsPresenter {
                         .extra_request_fields
                         .clone()
                         .map_or_else(|| "{}".to_string(), |value| value.to_string()),
-                    context_limit: None,
+                    // Issue #182: surface the persisted context window so the
+                    // editor's "CONTEXT LIMIT" field reflects the actual value
+                    // instead of always defaulting to 128_000.
+                    context_limit: Some(
+                        u32::try_from(profile.context_window_size).unwrap_or(u32::MAX),
+                    ),
                     show_thinking: profile.parameters.show_thinking,
                     enable_thinking: profile.parameters.enable_thinking,
                     thinking_budget: profile.parameters.thinking_budget,

--- a/src/presentation/view_command.rs
+++ b/src/presentation/view_command.rs
@@ -298,6 +298,16 @@ pub enum ViewCommand {
         context_length: Option<u32>,
     },
 
+    /// Reset the profile editor to a blank "new profile" state.
+    ///
+    /// Emitted by the presenter in response to
+    /// [`crate::events::types::UserEvent::OpenNewProfile`] so the editor
+    /// view can drop any stale state left over from a previous edit or
+    /// model-browse flow. The view should preserve only the cached list of
+    /// available API key labels (so the key dropdown stays populated) and
+    /// reset everything else via `ProfileEditorState::new_profile`.
+    ProfileEditorReset,
+
     /// Prefill profile editor with existing profile data for edit flow
     ProfileEditorLoad {
         id: Uuid,

--- a/src/services/profile.rs
+++ b/src/services/profile.rs
@@ -70,4 +70,16 @@ pub trait ProfileService: Send + Sync {
 
     /// Set a profile as the default
     async fn set_default(&self, id: Uuid) -> ServiceResult<()>;
+
+    /// Update the profile's `context_window_size` (the editor field labeled
+    /// "CONTEXT LIMIT").
+    ///
+    /// This lives outside `update`'s `parameters` blob because it is stored
+    /// at the profile level on disk, not inside `ModelParameters`. The
+    /// default implementation is a no-op so test doubles don't have to
+    /// implement it; the real [`super::profile_impl::ProfileServiceImpl`]
+    /// overrides it to persist the change. Issue #182.
+    async fn set_context_window_size(&self, _id: Uuid, _size: usize) -> ServiceResult<()> {
+        Ok(())
+    }
 }

--- a/src/services/profile_impl.rs
+++ b/src/services/profile_impl.rs
@@ -615,6 +615,26 @@ impl ProfileService for ProfileServiceImpl {
 
         Ok(())
     }
+
+    /// Persist a new `context_window_size` for an existing profile.
+    ///
+    /// Issue #182 — the profile editor "CONTEXT LIMIT" field is stored on
+    /// `ModelProfile` itself (not inside `ModelParameters`), so it has its
+    /// own setter rather than being smuggled through `update`'s already long
+    /// argument list.
+    async fn set_context_window_size(&self, id: Uuid, size: usize) -> ServiceResult<()> {
+        let mut profiles = self.profiles.write().await;
+        let profile = profiles
+            .iter_mut()
+            .find(|p| p.id == id)
+            .ok_or_else(|| super::ServiceError::NotFound(format!("Profile {id} not found")))?;
+        profile.context_window_size = size;
+        let updated_profile = profile.clone();
+        drop(profiles);
+
+        self.save_profile_to_disk(&updated_profile)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/ui_gpui/views/main_panel/command.rs
+++ b/src/ui_gpui/views/main_panel/command.rs
@@ -73,7 +73,10 @@ impl MainPanel {
             | ToolApprovalPolicyUpdated { .. } => self.forward_to_settings(cmd, cx),
 
             // ── model selector + profile editor ─────────────────────────
-            ModelSearchResults { .. } | ModelSelected { .. } | ProfileEditorLoad { .. } => {
+            ModelSearchResults { .. }
+            | ModelSelected { .. }
+            | ProfileEditorLoad { .. }
+            | ProfileEditorReset => {
                 self.handle_model_profile_command(cmd, cx);
             }
 
@@ -250,6 +253,17 @@ impl MainPanel {
                 }
                 self.navigation.navigate(ViewId::ProfileEditor);
                 cx.notify();
+            }
+            ViewCommand::ProfileEditorReset => {
+                // The view navigates to the editor itself (via `+` button or
+                // `Shift+=`). Here we only forward the reset command so the
+                // editor clears any stale state before becoming visible. See
+                // issue #182.
+                if let Some(ref profile_editor) = self.profile_editor_view {
+                    profile_editor.update(cx, |view, cx| {
+                        view.handle_command(ViewCommand::ProfileEditorReset, cx);
+                    });
+                }
             }
             _ => {}
         }

--- a/src/ui_gpui/views/main_panel/routing.rs
+++ b/src/ui_gpui/views/main_panel/routing.rs
@@ -76,6 +76,10 @@ pub struct CommandTargets {
     // Profile prefill state from model selector
     pub profile_prefill_selected_count: usize,
 
+    // Profile editor reset count (new-profile flow clearing stale state).
+    // See issue #182.
+    pub profile_editor_reset_count: usize,
+
     // Tool approval routing counters
     pub tool_approval_policy_count: usize,
     pub yolo_mode_changed_count: usize,
@@ -155,6 +159,11 @@ pub fn route_view_command(cmd: ViewCommand, targets: &mut CommandTargets) {
         // ── Profile prefill ────────────────────────────────────────────────
         ViewCommand::ModelSelected { .. } | ViewCommand::ProfileEditorLoad { .. } => {
             targets.profile_prefill_selected_count += 1;
+        }
+
+        // ── Profile editor reset (new-profile flow, issue #182) ──────────
+        ViewCommand::ProfileEditorReset => {
+            targets.profile_editor_reset_count += 1;
         }
 
         // ── Tool approval ────────────────────────────────────────────────

--- a/src/ui_gpui/views/profile_editor_view/mod.rs
+++ b/src/ui_gpui/views/profile_editor_view/mod.rs
@@ -511,16 +511,22 @@ impl ProfileEditorView {
                 provider_api_url,
                 context_length,
             } => {
-                self.state.is_new = true;
+                // Preserve `is_new`, `id`, `key_label`, `name`, `system_prompt`, etc.
+                // The Browse button keeps the editor's pre-existing state so that an
+                // edit-flow user does not lose their work (and does not silently
+                // create a duplicate profile) when picking a different model. See
+                // issue #182.
                 self.state.data.model_id.clone_from(&model_id);
                 self.state.data.api_type = match provider_id.as_str() {
                     "anthropic" => ApiType::Anthropic,
                     "openai" => ApiType::OpenAI,
                     _ => ApiType::Custom(provider_id.clone()),
                 };
+                // Only synthesise a name when the user has not already typed one.
                 if self.state.data.name.trim().is_empty() {
                     self.state.data.name = model_id;
                 }
+                // Only fill base_url when it has not been entered yet.
                 if self.state.data.base_url.trim().is_empty() {
                     self.state.data.base_url = provider_api_url
                         .filter(|url| !url.trim().is_empty())
@@ -584,9 +590,29 @@ impl ProfileEditorView {
                 self.state.data.available_keys = keys.iter().map(|k| k.label.clone()).collect();
             }
 
+            ViewCommand::ProfileEditorReset => {
+                tracing::info!(
+                    "ProfileEditorView: resetting to blank new-profile state (ProfileEditorReset)"
+                );
+                self.reset_to_new_profile();
+                self.request_api_key_refresh();
+            }
+
             _ => {}
         }
         cx.notify();
+    }
+
+    /// Reset the editor's `state` to a blank new-profile while preserving the
+    /// cached list of available API key labels (so the dropdown stays populated
+    /// without waiting for a fresh `ApiKeysListed` command).
+    ///
+    /// Used by both the Cancel/Esc/Cmd-W handlers and the `ProfileEditorReset`
+    /// view command. See issue #182.
+    pub(super) fn reset_to_new_profile(&mut self) {
+        let available_keys = std::mem::take(&mut self.state.data.available_keys);
+        self.state = ProfileEditorState::new_profile();
+        self.state.data.available_keys = available_keys;
     }
 }
 

--- a/src/ui_gpui/views/profile_editor_view/mod.rs
+++ b/src/ui_gpui/views/profile_editor_view/mod.rs
@@ -504,6 +504,9 @@ impl ProfileEditorView {
             } else {
                 None
             },
+            // Issue #182: carry the editor's "CONTEXT LIMIT" field through
+            // to the presenter so it actually gets persisted.
+            context_window_size: Some(self.state.data.context_limit as usize),
         });
 
         self.emit(&UserEvent::SaveProfile {

--- a/src/ui_gpui/views/profile_editor_view/mod.rs
+++ b/src/ui_gpui/views/profile_editor_view/mod.rs
@@ -72,6 +72,23 @@ impl ApiType {
             Self::Local => false,
         }
     }
+
+    /// Map a provider id string (as used by the model registry / persisted
+    /// profiles) to the corresponding `ApiType` variant.
+    ///
+    /// Centralised so every load / model-selection path stays in sync — see
+    /// issue #182 where omitting the `"local"` arm caused local-provider
+    /// profiles to be classified as `Custom`, which falsely required an API
+    /// key and disabled Save during an edit.
+    #[must_use]
+    pub fn from_provider_id(provider_id: &str) -> Self {
+        match provider_id {
+            "anthropic" => Self::Anthropic,
+            "openai" => Self::OpenAI,
+            "local" => Self::Local,
+            other => Self::Custom(other.to_string()),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -539,11 +556,7 @@ impl ProfileEditorView {
                 self.state.data.name = name;
                 self.state.data.model_id = model_id;
                 self.state.data.base_url = base_url;
-                self.state.data.api_type = match provider_id.as_str() {
-                    "anthropic" => ApiType::Anthropic,
-                    "openai" => ApiType::OpenAI,
-                    _ => ApiType::Custom(provider_id.clone()),
-                };
+                self.state.data.api_type = ApiType::from_provider_id(&provider_id);
                 self.state.data.key_label = api_key_label;
                 #[allow(clippy::cast_possible_truncation)]
                 {
@@ -598,11 +611,7 @@ impl ProfileEditorView {
         context_length: Option<u32>,
     ) {
         self.state.data.model_id.clone_from(&model_id);
-        self.state.data.api_type = match provider_id {
-            "anthropic" => ApiType::Anthropic,
-            "openai" => ApiType::OpenAI,
-            _ => ApiType::Custom(provider_id.to_string()),
-        };
+        self.state.data.api_type = ApiType::from_provider_id(provider_id);
         if self.state.data.name.trim().is_empty() {
             self.state.data.name = model_id;
         }

--- a/src/ui_gpui/views/profile_editor_view/mod.rs
+++ b/src/ui_gpui/views/profile_editor_view/mod.rs
@@ -112,6 +112,10 @@ pub struct ProfileEditorData {
 }
 
 impl ProfileEditorData {
+    /// Default `context_limit` used when no explicit value has been chosen
+    /// (matches the value assigned by [`ProfileEditorData::new`]).
+    pub const DEFAULT_CONTEXT_LIMIT: u32 = 128_000;
+
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -119,7 +123,7 @@ impl ProfileEditorData {
             max_tokens: "4096".to_string(),
             max_tokens_field_name: "max_tokens".to_string(),
             extra_request_fields: "{}".to_string(),
-            context_limit: 128_000,
+            context_limit: Self::DEFAULT_CONTEXT_LIMIT,
             show_thinking: true,
             thinking_budget: 10000,
             system_prompt: crate::models::profile::DEFAULT_SYSTEM_PROMPT.to_string(),
@@ -511,31 +515,7 @@ impl ProfileEditorView {
                 provider_api_url,
                 context_length,
             } => {
-                // Preserve `is_new`, `id`, `key_label`, `name`, `system_prompt`, etc.
-                // The Browse button keeps the editor's pre-existing state so that an
-                // edit-flow user does not lose their work (and does not silently
-                // create a duplicate profile) when picking a different model. See
-                // issue #182.
-                self.state.data.model_id.clone_from(&model_id);
-                self.state.data.api_type = match provider_id.as_str() {
-                    "anthropic" => ApiType::Anthropic,
-                    "openai" => ApiType::OpenAI,
-                    _ => ApiType::Custom(provider_id.clone()),
-                };
-                // Only synthesise a name when the user has not already typed one.
-                if self.state.data.name.trim().is_empty() {
-                    self.state.data.name = model_id;
-                }
-                // Only fill base_url when it has not been entered yet.
-                if self.state.data.base_url.trim().is_empty() {
-                    self.state.data.base_url = provider_api_url
-                        .filter(|url| !url.trim().is_empty())
-                        .unwrap_or_else(|| default_api_base_url_for_provider(&provider_id));
-                }
-                if let Some(limit) = context_length {
-                    self.state.data.context_limit = limit;
-                }
-                self.state.active_field = None;
+                self.apply_model_selected(&provider_id, model_id, provider_api_url, context_length);
             }
             ViewCommand::ProfileEditorLoad {
                 id,
@@ -601,6 +581,44 @@ impl ProfileEditorView {
             _ => {}
         }
         cx.notify();
+    }
+
+    /// Apply a `ViewCommand::ModelSelected` payload to the editor state.
+    ///
+    /// Preserves `is_new`, `id`, `key_label`, `name`, `system_prompt`, and any
+    /// user-customised `base_url` / `context_limit`. Only fields that are
+    /// unset (or at their defaults) are filled from the selected model. See
+    /// issue #182 — the Browse flow during an edit must not clobber user
+    /// work or silently spawn duplicate profiles.
+    fn apply_model_selected(
+        &mut self,
+        provider_id: &str,
+        model_id: String,
+        provider_api_url: Option<String>,
+        context_length: Option<u32>,
+    ) {
+        self.state.data.model_id.clone_from(&model_id);
+        self.state.data.api_type = match provider_id {
+            "anthropic" => ApiType::Anthropic,
+            "openai" => ApiType::OpenAI,
+            _ => ApiType::Custom(provider_id.to_string()),
+        };
+        if self.state.data.name.trim().is_empty() {
+            self.state.data.name = model_id;
+        }
+        if self.state.data.base_url.trim().is_empty() {
+            self.state.data.base_url = provider_api_url
+                .filter(|url| !url.trim().is_empty())
+                .unwrap_or_else(|| default_api_base_url_for_provider(provider_id));
+        }
+        if let Some(limit) = context_length {
+            if self.state.data.context_limit == 0
+                || self.state.data.context_limit == ProfileEditorData::DEFAULT_CONTEXT_LIMIT
+            {
+                self.state.data.context_limit = limit;
+            }
+        }
+        self.state.active_field = None;
     }
 
     /// Reset the editor's `state` to a blank new-profile while preserving the

--- a/src/ui_gpui/views/profile_editor_view/render.rs
+++ b/src/ui_gpui/views/profile_editor_view/render.rs
@@ -1,6 +1,6 @@
 //! Render implementation for `ProfileEditorView`.
 
-use super::{ActiveField, ApiType, ProfileEditorState, ProfileEditorView};
+use super::{ActiveField, ApiType, ProfileEditorView};
 use crate::config::default_api_base_url_for_provider;
 use crate::ui_gpui::theme::Theme;
 use gpui::{
@@ -47,8 +47,14 @@ impl ProfileEditorView {
                     .child("Cancel")
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|_this, _, _window, _cx| {
-                            tracing::info!("Cancel clicked - navigating to Settings");
+                        cx.listener(|this, _, _window, _cx| {
+                            tracing::info!(
+                                "Cancel clicked - resetting editor state and navigating to \
+                                 Settings"
+                            );
+                            // Reset so a subsequent `+` new-profile flow doesn't see
+                            // leftover state from the cancelled edit. See issue #182.
+                            this.reset_to_new_profile();
                             crate::ui_gpui::navigation_channel().request_navigate(
                                 crate::presentation::view_command::ViewId::Settings,
                             );
@@ -226,11 +232,14 @@ impl ProfileEditorView {
                                 MouseButton::Left,
                                 cx.listener(|this, _, _window, _cx| {
                                     tracing::info!(
-                                        "Browse model clicked - navigating to ModelSelector"
+                                        "Browse model clicked - navigating to ModelSelector \
+                                         (preserving edit state)"
                                     );
-                                    let available_keys = this.state.data.available_keys.clone();
-                                    this.state = ProfileEditorState::new_profile();
-                                    this.state.data.available_keys = available_keys;
+                                    // Do NOT reset state here — preserve `id`, `key_label`,
+                                    // `name`, `is_new`, `system_prompt`, etc. so that an
+                                    // edit-flow user can swap models without losing their
+                                    // work. `ModelSelected` will only update the model
+                                    // fields on return. See issue #182.
                                     this.request_api_key_refresh();
                                     crate::ui_gpui::navigation_channel().request_navigate(
                                         crate::presentation::view_command::ViewId::ModelSelector,
@@ -894,6 +903,9 @@ impl gpui::Render for ProfileEditorView {
                     let modifiers = &event.keystroke.modifiers;
 
                     if key == "escape" || (modifiers.platform && key == "w") {
+                        // Match the Cancel button: discard any edits so the next
+                        // new-profile flow starts blank. See issue #182.
+                        this.reset_to_new_profile();
                         crate::ui_gpui::navigation_channel()
                             .request_navigate(crate::presentation::view_command::ViewId::Settings);
                         return;

--- a/src/ui_gpui/views/profile_editor_view/tests.rs
+++ b/src/ui_gpui/views/profile_editor_view/tests.rs
@@ -608,3 +608,48 @@ fn api_type_from_provider_id_covers_all_known_providers() {
         ApiType::Custom("ollama".to_string()),
     );
 }
+
+/// Regression test for issue #182: the editor's CONTEXT LIMIT field must be
+/// included in the save payload so the presenter can persist it. Before the
+/// fix, `emit_save_profile` built a `ModelProfileParameters` without
+/// `context_window_size`, so any edit to the field was silently dropped.
+#[gpui::test]
+async fn emit_save_profile_carries_context_window_size_for_issue_182(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(ProfileEditorView::new);
+
+    view.update(cx, |view: &mut ProfileEditorView, cx| {
+        view.set_bridge(Arc::clone(&bridge));
+        view.handle_command(
+            ViewCommand::ModelSelected {
+                provider_id: "openai".to_string(),
+                model_id: "gpt-4.1".to_string(),
+                provider_api_url: None,
+                context_length: Some(128_000),
+            },
+            cx,
+        );
+        view.state.data.key_label = "openai-key".to_string();
+        // Simulate the user typing into the CONTEXT LIMIT field after
+        // selecting the model.
+        view.state.data.context_limit = 64_000;
+        view.emit_save_profile();
+    });
+
+    // Drain the RefreshApiKeys event the bridge always emits first.
+    let _ = user_rx.recv().expect("refresh api keys event");
+
+    let event = user_rx.recv().expect("save profile event");
+    let UserEvent::SaveProfile { profile } = event else {
+        panic!("expected SaveProfile, got {event:?}");
+    };
+    let parameters = profile
+        .parameters
+        .as_ref()
+        .expect("save payload must include parameters");
+    assert_eq!(
+        parameters.context_window_size,
+        Some(64_000),
+        "CONTEXT LIMIT must round-trip through the save payload"
+    );
+}

--- a/src/ui_gpui/views/profile_editor_view/tests.rs
+++ b/src/ui_gpui/views/profile_editor_view/tests.rs
@@ -268,3 +268,232 @@ async fn validate_advanced_request_json_sets_validation_message(cx: &mut TestApp
         );
     });
 }
+
+/// Regression test for issue #182 (Bug 1).
+///
+/// When a user is editing an existing profile and clicks Browse to pick a
+/// different model, the editor must preserve the profile's identity
+/// (`id`, `key_label`, `is_new = false`, `name`, `system_prompt`) so that:
+///
+///   1. The API KEY dropdown remains populated, keeping `can_save()` true.
+///   2. Saving updates the original profile instead of silently creating a
+///      duplicate (because `data.id` is still the original UUID).
+#[gpui::test]
+async fn model_selected_preserves_edit_state_for_issue_182(cx: &mut TestAppContext) {
+    let profile_id = Uuid::new_v4();
+    let view = cx.new(ProfileEditorView::new);
+
+    view.update(cx, |view: &mut ProfileEditorView, cx| {
+        // Simulate the Edit flow: presenter loads an existing profile.
+        view.handle_command(
+            ViewCommand::ProfileEditorLoad {
+                id: profile_id,
+                name: "My Anthropic".to_string(),
+                provider_id: "anthropic".to_string(),
+                model_id: "claude-3-5-sonnet".to_string(),
+                base_url: "https://api.anthropic.com/v1".to_string(),
+                api_key_label: "anthropic-key".to_string(),
+                temperature: 0.7,
+                max_tokens: Some(4096),
+                max_tokens_field_name: "max_tokens".to_string(),
+                extra_request_fields: "{}".to_string(),
+                context_limit: Some(200_000),
+                show_thinking: true,
+                enable_thinking: false,
+                thinking_budget: None,
+                system_prompt: "Be helpful.".to_string(),
+            },
+            cx,
+        );
+
+        assert!(!view.state.is_new, "sanity: starting in edit mode");
+        assert!(view.state.data.can_save(), "sanity: edit form is savable");
+
+        // User clicks Browse → picks a new model. The editor receives
+        // `ModelSelected`.
+        view.handle_command(
+            ViewCommand::ModelSelected {
+                provider_id: "openai".to_string(),
+                model_id: "gpt-4.1".to_string(),
+                provider_api_url: Some("https://api.openai.com/v1".to_string()),
+                context_length: Some(128_000),
+            },
+            cx,
+        );
+
+        // Identity of the profile must be preserved.
+        assert!(
+            !view.state.is_new,
+            "is_new must remain false so Save issues an update, not a create"
+        );
+        assert_eq!(
+            view.state.data.id.as_deref(),
+            Some(profile_id.to_string().as_str()),
+            "profile id must be preserved through model browse"
+        );
+
+        // Model fields must be updated.
+        assert_eq!(view.state.data.model_id, "gpt-4.1");
+        assert_eq!(view.state.data.api_type, ApiType::OpenAI);
+
+        // Fields that had user-entered values must NOT be overwritten.
+        assert_eq!(view.state.data.name, "My Anthropic");
+        assert_eq!(view.state.data.base_url, "https://api.anthropic.com/v1");
+        assert_eq!(view.state.data.system_prompt, "Be helpful.");
+
+        // The API key selection must survive, keeping Save enabled.
+        assert_eq!(view.state.data.key_label, "anthropic-key");
+        assert!(
+            view.state.data.can_save(),
+            "Save must remain enabled after Browse during an edit"
+        );
+    });
+}
+
+/// Regression test for issue #182 (Bug 2).
+///
+/// The `ProfileEditorReset` view command must clear the editor to a blank
+/// new-profile state while preserving the cached `available_keys` list.
+#[gpui::test]
+async fn profile_editor_reset_clears_state_but_preserves_keys_for_issue_182(
+    cx: &mut TestAppContext,
+) {
+    let (bridge, user_rx) = make_bridge();
+    let stale_profile_id = Uuid::new_v4();
+    let view = cx.new(ProfileEditorView::new);
+
+    view.update(cx, |view: &mut ProfileEditorView, cx| {
+        view.set_bridge(Arc::clone(&bridge));
+        // Drop the `RefreshApiKeys` emitted by `set_bridge` so only the
+        // reset-triggered refresh remains.
+        let _ = user_rx.recv().expect("refresh api keys from set_bridge");
+
+        // Populate editor with stale data as if we had been editing a profile.
+        view.handle_command(
+            ViewCommand::ProfileEditorLoad {
+                id: stale_profile_id,
+                name: "Stale".to_string(),
+                provider_id: "anthropic".to_string(),
+                model_id: "claude".to_string(),
+                base_url: "https://api.anthropic.com/v1".to_string(),
+                api_key_label: "anthropic-key".to_string(),
+                temperature: 0.7,
+                max_tokens: Some(4096),
+                max_tokens_field_name: "max_tokens".to_string(),
+                extra_request_fields: "{}".to_string(),
+                context_limit: Some(200_000),
+                show_thinking: true,
+                enable_thinking: false,
+                thinking_budget: None,
+                system_prompt: "Old prompt".to_string(),
+            },
+            cx,
+        );
+        view.handle_command(
+            ViewCommand::ApiKeysListed {
+                keys: vec![
+                    ApiKeyInfo {
+                        label: "anthropic-key".to_string(),
+                        masked_value: "••••1234".to_string(),
+                        used_by: vec!["Stale".to_string()],
+                    },
+                    ApiKeyInfo {
+                        label: "openai-key".to_string(),
+                        masked_value: "••••5678".to_string(),
+                        used_by: vec![],
+                    },
+                ],
+            },
+            cx,
+        );
+
+        // Fire the reset command — as if the user clicked `+` and the
+        // presenter forwarded `UserEvent::OpenNewProfile` back as
+        // `ProfileEditorReset`.
+        view.handle_command(ViewCommand::ProfileEditorReset, cx);
+
+        assert!(
+            view.state.is_new,
+            "reset must flip back to new-profile mode"
+        );
+        assert!(view.state.data.id.is_none(), "profile id must be cleared");
+        assert_eq!(view.state.data.name, "", "name must be cleared");
+        assert_eq!(view.state.data.model_id, "", "model must be cleared");
+        assert_eq!(view.state.data.base_url, "", "base_url must be cleared");
+        assert_eq!(
+            view.state.data.key_label, "",
+            "key selection must be cleared"
+        );
+        assert_eq!(
+            view.state.data.system_prompt,
+            crate::models::profile::DEFAULT_SYSTEM_PROMPT,
+            "system prompt must fall back to the default"
+        );
+
+        // Available keys must survive so the dropdown doesn't flicker empty.
+        assert_eq!(
+            view.state.data.available_keys,
+            vec!["anthropic-key".to_string(), "openai-key".to_string()],
+        );
+    });
+
+    // Reset requests a refresh so we pick up any newly-stored keys.
+    assert_eq!(
+        user_rx.recv().expect("reset requests api key refresh"),
+        UserEvent::RefreshApiKeys
+    );
+}
+
+/// Regression test for issue #182: Cancel must drop stale editor state so
+/// that the next `+` (new profile) flow starts blank.
+#[gpui::test]
+async fn reset_to_new_profile_helper_clears_edit_state_for_issue_182(cx: &mut TestAppContext) {
+    let profile_id = Uuid::new_v4();
+    let view = cx.new(ProfileEditorView::new);
+
+    view.update(cx, |view: &mut ProfileEditorView, cx| {
+        view.handle_command(
+            ViewCommand::ProfileEditorLoad {
+                id: profile_id,
+                name: "My Anthropic".to_string(),
+                provider_id: "anthropic".to_string(),
+                model_id: "claude-3-5-sonnet".to_string(),
+                base_url: "https://api.anthropic.com/v1".to_string(),
+                api_key_label: "anthropic-key".to_string(),
+                temperature: 0.7,
+                max_tokens: Some(4096),
+                max_tokens_field_name: "max_tokens".to_string(),
+                extra_request_fields: "{}".to_string(),
+                context_limit: Some(200_000),
+                show_thinking: true,
+                enable_thinking: false,
+                thinking_budget: None,
+                system_prompt: "Be helpful.".to_string(),
+            },
+            cx,
+        );
+        view.handle_command(
+            ViewCommand::ApiKeysListed {
+                keys: vec![ApiKeyInfo {
+                    label: "anthropic-key".to_string(),
+                    masked_value: "••••1234".to_string(),
+                    used_by: vec!["My Anthropic".to_string()],
+                }],
+            },
+            cx,
+        );
+
+        // Cancel handler behaviour: reset before navigating.
+        view.reset_to_new_profile();
+
+        assert!(view.state.is_new);
+        assert!(view.state.data.id.is_none());
+        assert_eq!(view.state.data.name, "");
+        assert_eq!(view.state.data.key_label, "");
+        assert_eq!(
+            view.state.data.available_keys,
+            vec!["anthropic-key".to_string()],
+            "available_keys must survive the reset"
+        );
+    });
+}

--- a/src/ui_gpui/views/profile_editor_view/tests.rs
+++ b/src/ui_gpui/views/profile_editor_view/tests.rs
@@ -340,12 +340,52 @@ async fn model_selected_preserves_edit_state_for_issue_182(cx: &mut TestAppConte
         assert_eq!(view.state.data.name, "My Anthropic");
         assert_eq!(view.state.data.base_url, "https://api.anthropic.com/v1");
         assert_eq!(view.state.data.system_prompt, "Be helpful.");
+        // A user-customised context_limit (200_000) must not be clobbered by
+        // the newly-selected model's native context length (128_000).
+        assert_eq!(
+            view.state.data.context_limit, 200_000,
+            "user-customised context_limit must survive model Browse"
+        );
 
         // The API key selection must survive, keeping Save enabled.
         assert_eq!(view.state.data.key_label, "anthropic-key");
         assert!(
             view.state.data.can_save(),
             "Save must remain enabled after Browse during an edit"
+        );
+    });
+}
+
+/// Regression test for issue #182 (Bug 1) — new-profile flow still adopts the
+/// model's native context length.
+///
+/// When a user is starting a brand-new profile (editor at defaults), selecting
+/// a model should populate `context_limit` from the model's `context_length`
+/// so the form reflects that model's capabilities out of the box.
+#[gpui::test]
+async fn model_selected_on_blank_editor_adopts_context_length(cx: &mut TestAppContext) {
+    let view = cx.new(ProfileEditorView::new);
+
+    view.update(cx, |view: &mut ProfileEditorView, cx| {
+        // Sanity: blank editor starts at the default context_limit.
+        assert_eq!(
+            view.state.data.context_limit,
+            ProfileEditorData::DEFAULT_CONTEXT_LIMIT
+        );
+
+        view.handle_command(
+            ViewCommand::ModelSelected {
+                provider_id: "anthropic".to_string(),
+                model_id: "claude-3-5-sonnet".to_string(),
+                provider_api_url: Some("https://api.anthropic.com/v1".to_string()),
+                context_length: Some(200_000),
+            },
+            cx,
+        );
+
+        assert_eq!(
+            view.state.data.context_limit, 200_000,
+            "blank editor should adopt the selected model's native context length"
         );
     });
 }

--- a/src/ui_gpui/views/profile_editor_view/tests.rs
+++ b/src/ui_gpui/views/profile_editor_view/tests.rs
@@ -537,3 +537,74 @@ async fn reset_to_new_profile_helper_clears_edit_state_for_issue_182(cx: &mut Te
         );
     });
 }
+
+/// Regression test for issue #182 (Bug 3 — local-provider profiles): loading a
+/// profile whose `provider_id` is `"local"` must classify it as
+/// `ApiType::Local` (not `ApiType::Custom`), so the editor knows it does not
+/// require an API key and Save stays enabled even though the profile has no
+/// keychain entry.
+///
+/// User repro: edit "autoshot model remote" (a local profile), change the
+/// model name in the MODEL field, then try to Save → Save was disabled.
+#[gpui::test]
+async fn local_profile_load_keeps_save_enabled_for_issue_182(cx: &mut TestAppContext) {
+    let profile_id = Uuid::new_v4();
+    let view = cx.new(ProfileEditorView::new);
+
+    view.update(cx, |view: &mut ProfileEditorView, cx| {
+        view.handle_command(
+            ViewCommand::ProfileEditorLoad {
+                id: profile_id,
+                name: "autoshot model remote".to_string(),
+                provider_id: "local".to_string(),
+                model_id: "dpo_merged_q4_k_m.gguf".to_string(),
+                base_url: "http://fed-net.internet-box.ch:8080/".to_string(),
+                // Local profiles have no keychain label.
+                api_key_label: String::new(),
+                temperature: 0.7,
+                max_tokens: Some(4096),
+                max_tokens_field_name: "max_tokens".to_string(),
+                extra_request_fields: "{}".to_string(),
+                context_limit: Some(8_192),
+                show_thinking: true,
+                enable_thinking: false,
+                thinking_budget: None,
+                system_prompt: "Be helpful.".to_string(),
+            },
+            cx,
+        );
+
+        // Provider-id "local" must map to ApiType::Local, not Custom.
+        assert_eq!(view.state.data.api_type, ApiType::Local);
+        assert!(
+            !view.state.data.api_type.requires_api_key(),
+            "local profiles must not require an API key"
+        );
+        assert!(
+            view.state.data.can_save(),
+            "Save must be enabled for a local profile loaded from disk"
+        );
+
+        // The user changes the model name in the MODEL field — Save must
+        // remain enabled.
+        view.state.data.model_id = "different_model.gguf".to_string();
+        assert!(
+            view.state.data.can_save(),
+            "Save must remain enabled after editing the model field on a local profile"
+        );
+    });
+}
+
+/// Regression test: `ApiType::from_provider_id` must round-trip the four
+/// canonical provider ids correctly so that load / model-selection paths can
+/// never drift out of sync again (root cause of the local-profile bug).
+#[test]
+fn api_type_from_provider_id_covers_all_known_providers() {
+    assert_eq!(ApiType::from_provider_id("anthropic"), ApiType::Anthropic);
+    assert_eq!(ApiType::from_provider_id("openai"), ApiType::OpenAI);
+    assert_eq!(ApiType::from_provider_id("local"), ApiType::Local);
+    assert_eq!(
+        ApiType::from_provider_id("ollama"),
+        ApiType::Custom("ollama".to_string()),
+    );
+}

--- a/src/ui_gpui/views/settings_view/mod.rs
+++ b/src/ui_gpui/views/settings_view/mod.rs
@@ -627,6 +627,9 @@ impl SettingsView {
         }
 
         if key == "=" && modifiers.shift {
+            // Mirror the `+` button: signal a fresh new-profile flow so the
+            // editor view resets. See issue #182.
+            self.emit(&UserEvent::OpenNewProfile);
             Self::navigate_to_profile_editor();
             return;
         }

--- a/src/ui_gpui/views/settings_view/render.rs
+++ b/src/ui_gpui/views/settings_view/render.rs
@@ -218,8 +218,13 @@ impl SettingsView {
                     .child("+")
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|_this, _, _window, _cx| {
-                            tracing::info!("Add profile clicked - navigating to ModelSelector");
+                        cx.listener(|this, _, _window, _cx| {
+                            tracing::info!(
+                                "Add profile clicked - emitting OpenNewProfile and navigating"
+                            );
+                            // Tell the presenter this is a fresh new-profile flow so the
+                            // editor view resets (clears any stale edit state). See issue #182.
+                            this.emit(&UserEvent::OpenNewProfile);
                             Self::navigate_to_profile_editor();
                         }),
                     ),

--- a/src/ui_gpui/views/settings_view/tests.rs
+++ b/src/ui_gpui/views/settings_view/tests.rs
@@ -435,6 +435,10 @@ async fn key_handling_navigates_and_emits_profile_events(cx: &mut TestAppContext
         user_rx.recv().unwrap(),
         UserEvent::EditProfile { id: profile_b }
     );
+    // `shift-=` now emits `OpenNewProfile` so the presenter can reset the
+    // editor view before the `+`/`Shift+=` flow navigates into it. See
+    // issue #182.
+    assert_eq!(user_rx.recv().unwrap(), UserEvent::OpenNewProfile);
     assert_eq!(
         user_rx.recv().unwrap(),
         UserEvent::SelectTheme {

--- a/tests/history_and_settings_presenter_tests.rs
+++ b/tests/history_and_settings_presenter_tests.rs
@@ -1177,7 +1177,7 @@ mod settings_presenter_tests {
                 )
                 .expect("extra request fields should serialize"),
 
-                context_limit: None,
+                context_limit: Some(u32::try_from(profile.context_window_size).unwrap_or(u32::MAX)),
                 show_thinking: profile.parameters.show_thinking,
                 enable_thinking: profile.parameters.enable_thinking,
                 thinking_budget: profile.parameters.thinking_budget,
@@ -1226,7 +1226,9 @@ mod settings_presenter_tests {
                 max_tokens: legacy_profile.parameters.max_tokens,
                 max_tokens_field_name: "max_tokens".to_string(),
                 extra_request_fields: "{}".to_string(),
-                context_limit: None,
+                context_limit: Some(
+                    u32::try_from(legacy_profile.context_window_size).unwrap_or(u32::MAX),
+                ),
                 show_thinking: legacy_profile.parameters.show_thinking,
                 enable_thinking: legacy_profile.parameters.enable_thinking,
                 thinking_budget: legacy_profile.parameters.thinking_budget,

--- a/tests/profile_editor_save_payload_mapping_tests.rs
+++ b/tests/profile_editor_save_payload_mapping_tests.rs
@@ -16,6 +16,10 @@ struct RecordingProfileService {
     create_calls: Arc<Mutex<Vec<CreateCall>>>,
     update_calls: Arc<Mutex<Vec<UpdateCall>>>,
     update_result: Arc<Mutex<Option<ServiceResult<ModelProfile>>>>,
+    /// Records `(profile_id, size)` pairs each time the presenter persists
+    /// a new context window via [`ProfileService::set_context_window_size`]
+    /// (issue #182).
+    set_context_window_calls: Arc<Mutex<Vec<(uuid::Uuid, usize)>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -55,6 +59,13 @@ impl RecordingProfileService {
         self.create_calls
             .lock()
             .expect("create calls lock poisoned")
+            .clone()
+    }
+
+    fn set_context_window_calls(&self) -> Vec<(uuid::Uuid, usize)> {
+        self.set_context_window_calls
+            .lock()
+            .expect("set_context_window calls lock poisoned")
             .clone()
     }
 }
@@ -164,6 +175,14 @@ impl ProfileService for RecordingProfileService {
     async fn set_default(&self, _id: uuid::Uuid) -> ServiceResult<()> {
         Ok(())
     }
+
+    async fn set_context_window_size(&self, id: uuid::Uuid, size: usize) -> ServiceResult<()> {
+        self.set_context_window_calls
+            .lock()
+            .expect("set_context_window calls lock poisoned")
+            .push((id, size));
+        Ok(())
+    }
 }
 
 fn payload(max_tokens: Option<u32>, max_tokens_field_name: &str) -> EventModelProfile {
@@ -185,6 +204,7 @@ fn payload(max_tokens: Option<u32>, max_tokens_field_name: &str) -> EventModelPr
             show_thinking: Some(true),
             enable_thinking: Some(true),
             thinking_budget: Some(12000),
+            context_window_size: None,
         }),
         system_prompt: Some("Be concise".to_string()),
     }
@@ -343,5 +363,57 @@ async fn test_save_profile_payload_fallback_create_uses_payload_provider_and_mod
         create.parameters.extra_request_fields,
         Some(serde_json::json!({"reasoning": {"effort": "medium"}})),
         "extra_request_fields should survive the fallback create path"
+    );
+}
+
+/// Issue #182: when the editor save payload carries a `context_window_size`,
+/// the presenter must persist it via `ProfileService::set_context_window_size`
+/// after the regular `update`. Before the fix, the field was dropped on the
+/// floor and the on-disk profile kept its previous value.
+#[tokio::test]
+async fn save_profile_payload_persists_context_window_size_for_issue_182() {
+    let event_bus_sender: tokio::sync::broadcast::Sender<personal_agent::events::AppEvent> =
+        tokio::sync::broadcast::channel::<personal_agent::events::AppEvent>(32).0;
+    let (view_tx, mut view_rx) =
+        tokio::sync::broadcast::channel::<personal_agent::presentation::ViewCommand>(32);
+
+    let recording = RecordingProfileService::default();
+    let profile_service: Arc<dyn ProfileService> = Arc::new(recording.clone());
+
+    let mut presenter = personal_agent::presentation::ProfileEditorPresenter::new(
+        profile_service,
+        &event_bus_sender,
+        view_tx,
+    );
+    presenter
+        .start()
+        .await
+        .expect("presenter start must succeed");
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let mut save_payload = payload(Some(2048), "max_completion_tokens");
+    if let Some(ref mut params) = save_payload.parameters {
+        params.context_window_size = Some(64_000);
+    }
+    let expected_id = save_payload.id;
+
+    event_bus_sender
+        .send(personal_agent::events::AppEvent::User(
+            personal_agent::events::types::UserEvent::SaveProfile {
+                profile: Box::new(save_payload),
+            },
+        ))
+        .ok();
+
+    let _ = tokio::time::timeout(std::time::Duration::from_millis(250), view_rx.recv())
+        .await
+        .expect("timed out waiting for ProfileUpdated")
+        .expect("view channel closed");
+
+    let calls = recording.set_context_window_calls();
+    assert_eq!(
+        calls,
+        vec![(expected_id, 64_000)],
+        "presenter must persist context_window_size via set_context_window_size"
     );
 }

--- a/tests/profile_editor_view_tests.rs
+++ b/tests/profile_editor_view_tests.rs
@@ -153,6 +153,7 @@ fn emit_save_payload(data: &ProfileEditorData) -> personal_agent::events::types:
             } else {
                 None
             },
+            context_window_size: Some(data.context_limit as usize),
         }),
         system_prompt: Some(data.system_prompt.clone()),
     }

--- a/tests/remaining_presenter_coverage_tests.rs
+++ b/tests/remaining_presenter_coverage_tests.rs
@@ -524,6 +524,7 @@ async fn profile_editor_handles_save_paths_and_connection_feedback() {
             show_thinking: Some(true),
             enable_thinking: Some(true),
             thinking_budget: Some(512),
+            context_window_size: None,
         }),
         system_prompt: Some("Be helpful".to_string()),
     };


### PR DESCRIPTION
## Summary

Fixes two related state-management bugs in the Profile Editor reported in issue #182:

1. **Save disabled after Browse during edit** — editing a profile and changing the model via Browse made Save un-clickable. If the user worked around it, the save silently created a duplicate profile instead of updating the original.
2. **New-profile form pre-populated** — after cancelling an edit, clicking **+** (or pressing Shift+=) opened the editor with fields from the profile just edited, and the title bar still read "Edit Profile".

Both share the same root cause: the Profile Editor view retained in-memory state across navigations, and the Browse / new-profile / Cancel paths neither reset nor correctly preserved that state.

## Changes

- **New event + command pair**: `UserEvent::OpenNewProfile` → `ProfileEditorPresenter` → `ViewCommand::ProfileEditorReset`. The presenter turns the user intent into a reset command; the view layer drives the actual navigation, matching the existing pattern for other editor flows.
- **MainPanel dispatch**: `ProfileEditorReset` is forwarded to the editor without triggering navigation (view navigates itself via the `+` button / keyboard shortcut). The routing test surface picks up a new `profile_editor_reset_count` counter.
- **`ProfileEditorView::reset_to_new_profile()`** — a single helper that swaps to `ProfileEditorState::new_profile()` while preserving the cached `available_keys`, so the key dropdown doesn't blank out during the async refresh.
- **Browse no longer wipes state.** The Browse button now just navigates. `ModelSelected` only mutates model-related fields (`model_id`, `api_type`, and conditionally `name`/`base_url`/`context_limit`) — `id`, `key_label`, `is_new`, `system_prompt`, and other edit-flow fields are preserved.
- **Cancel / Esc / Cmd-W** now call `reset_to_new_profile()` before navigating back to Settings, so the next entry is clean.
- **Settings + button / Shift+=** emit `UserEvent::OpenNewProfile` before navigating, ensuring the editor is reset before it becomes visible.

## Tests

- `profile_editor_view::tests::model_selected_preserves_edit_state_for_issue_182` — locks in Bug 1 fix: after `ProfileEditorLoad` + `ModelSelected`, `is_new == false`, `id` / `key_label` / `name` / `system_prompt` preserved, model fields updated, `can_save()` still true.
- `profile_editor_view::tests::profile_editor_reset_clears_state_but_preserves_keys_for_issue_182` — locks in Bug 2 fix: `ProfileEditorReset` clears the form but keeps `available_keys` and triggers `RefreshApiKeys`.
- `profile_editor_view::tests::reset_to_new_profile_helper_clears_edit_state_for_issue_182` — covers the Cancel-button reset path directly.
- `settings_view::tests::key_handling_navigates_and_emits_profile_events` — now asserts `Shift+=` emits `UserEvent::OpenNewProfile`.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test --lib --tests` ✓ (846 lib tests + all integration suites, no failures)
- `lizard -C 50 -L 100 -w src/` ✓ (no complexity/length regressions)

Fixes #182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift+= shortcut and the Add (+) button now start a fresh New Profile flow that clears prior edit state.

* **Bug Fixes**
  * New-profile flow reliably resets stale profile-editor fields while preserving cached API keys.
  * Browsing models no longer overwrites user-entered fields; cancel now discards in-progress changes consistently.
  * Provider type handling improved for local providers.

* **Tests**
  * Added regression tests covering profile editor state, reset, and model-selection behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->