### PR TITLE
Fix History panel search input routing (Fixes #180)

### DIFF
--- a/src/ui_gpui/views/conversation_list/history_panel.rs
+++ b/src/ui_gpui/views/conversation_list/history_panel.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use gpui::{div, prelude::*, px, Entity, FocusHandle, FontWeight, MouseButton};
+use gpui::{div, prelude::*, px, Entity, FontWeight, MouseButton};
 
 use super::{ConversationListMode, ConversationListView};
 use crate::presentation::view_command::ViewId;
@@ -20,17 +20,13 @@ use crate::ui_gpui::views::main_panel::MainPanelAppState;
 /// Container view used when History is opened as a popin (full panel).
 pub struct HistoryPanelView {
     list: Entity<ConversationListView>,
-    focus_handle: FocusHandle,
 }
 
 impl HistoryPanelView {
     pub fn new(cx: &mut gpui::Context<Self>) -> Self {
         let list =
             cx.new(|child_cx| ConversationListView::new(ConversationListMode::FullPanel, child_cx));
-        Self {
-            list,
-            focus_handle: cx.focus_handle(),
-        }
+        Self { list }
     }
 
     /// Inject the bridge into the embedded list view.
@@ -55,6 +51,17 @@ impl HistoryPanelView {
     #[must_use]
     pub const fn list_entity(&self) -> &Entity<ConversationListView> {
         &self.list
+    }
+
+    /// Apply backend-supplied search results to the embedded list.
+    pub fn apply_search_results(
+        &self,
+        results: Vec<crate::presentation::view_command::ConversationSearchResult>,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        self.list.update(cx, |list, list_cx| {
+            list.apply_search_results(results, list_cx);
+        });
     }
 
     /// Read the current list of conversations from the embedded list view.
@@ -129,8 +136,8 @@ impl HistoryPanelView {
 }
 
 impl gpui::Focusable for HistoryPanelView {
-    fn focus_handle(&self, _cx: &gpui::App) -> FocusHandle {
-        self.focus_handle.clone()
+    fn focus_handle(&self, cx: &gpui::App) -> gpui::FocusHandle {
+        self.list.read(cx).focus_handle(cx)
     }
 }
 

--- a/src/ui_gpui/views/conversation_list/ime.rs
+++ b/src/ui_gpui/views/conversation_list/ime.rs
@@ -1,0 +1,140 @@
+//! IME/input handling for `ConversationListView`.
+//!
+//! The shared list is embedded directly in the popin History panel, so it must
+//! own its own input handler rather than relying on `ChatView` to proxy typed
+//! text from the popout sidebar.
+//!
+//! @plan PLAN-20260420-ISSUE180.P03
+//! @requirement REQ-180-001
+
+use std::ops::Range;
+
+use gpui::{Bounds, Pixels, UTF16Selection};
+
+use super::ConversationListView;
+
+fn utf8_offset_to_utf16(text: &str, utf8_offset: usize) -> usize {
+    text[..utf8_offset.min(text.len())].encode_utf16().count()
+}
+
+fn utf16_offset_to_utf8(text: &str, utf16_offset: usize) -> usize {
+    let mut utf16_count = 0;
+    for (byte_idx, ch) in text.char_indices() {
+        if utf16_count >= utf16_offset {
+            return byte_idx;
+        }
+        utf16_count += ch.len_utf16();
+    }
+    text.len()
+}
+
+impl gpui::EntityInputHandler for ConversationListView {
+    fn text_for_range(
+        &mut self,
+        range: Range<usize>,
+        _adjusted_range: &mut Option<Range<usize>>,
+        _window: &mut gpui::Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<String> {
+        let text = self.active_input_text().to_string();
+        let start = utf16_offset_to_utf8(&text, range.start);
+        let end = utf16_offset_to_utf8(&text, range.end);
+        Some(text[start..end].to_string())
+    }
+
+    fn selected_text_range(
+        &mut self,
+        _ignore_disabled_input: bool,
+        _window: &mut gpui::Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<UTF16Selection> {
+        let text = self.active_input_text().to_string();
+        let cursor_utf8 = self.active_cursor_position().min(text.len());
+        let cursor_utf16 = utf8_offset_to_utf16(&text, cursor_utf8);
+        Some(UTF16Selection {
+            range: cursor_utf16..cursor_utf16,
+            reversed: false,
+        })
+    }
+
+    fn marked_text_range(
+        &self,
+        _window: &mut gpui::Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<Range<usize>> {
+        None
+    }
+
+    fn unmark_text(&mut self, _window: &mut gpui::Window, cx: &mut gpui::Context<Self>) {
+        cx.notify();
+    }
+
+    fn replace_text_in_range(
+        &mut self,
+        range: Option<Range<usize>>,
+        text: &str,
+        _window: &mut gpui::Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if self.state.conversation_title_editing {
+            if self.state.rename_replace_on_next_char {
+                self.state.conversation_title_input.clear();
+                self.state.rename_replace_on_next_char = false;
+            }
+            let title = &mut self.state.conversation_title_input;
+            if let Some(r) = range {
+                let start = utf16_offset_to_utf8(title, r.start);
+                let end = utf16_offset_to_utf8(title, r.end);
+                title.replace_range(start..end, text);
+            } else {
+                title.push_str(text);
+            }
+            cx.notify();
+            return;
+        }
+
+        if self.state.sidebar_search_focused {
+            let query = &mut self.state.sidebar_search_query;
+            if let Some(r) = range {
+                let start = utf16_offset_to_utf8(query, r.start);
+                let end = utf16_offset_to_utf8(query, r.end);
+                query.replace_range(start..end, text);
+            } else {
+                query.push_str(text);
+            }
+            self.trigger_sidebar_search(cx);
+            cx.notify();
+        }
+    }
+
+    fn replace_and_mark_text_in_range(
+        &mut self,
+        range: Option<Range<usize>>,
+        new_text: &str,
+        _new_selected_range: Option<Range<usize>>,
+        window: &mut gpui::Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        self.replace_text_in_range(range, new_text, window, cx);
+    }
+
+    fn bounds_for_range(
+        &mut self,
+        _range_utf16: Range<usize>,
+        element_bounds: Bounds<Pixels>,
+        _window: &mut gpui::Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<Bounds<Pixels>> {
+        Some(element_bounds)
+    }
+
+    fn character_index_for_point(
+        &mut self,
+        _point: gpui::Point<Pixels>,
+        _window: &mut gpui::Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> Option<usize> {
+        let text = self.active_input_text().to_string();
+        Some(utf8_offset_to_utf16(&text, self.active_cursor_position()))
+    }
+}

--- a/src/ui_gpui/views/conversation_list/mod.rs
+++ b/src/ui_gpui/views/conversation_list/mod.rs
@@ -12,6 +12,7 @@
 //! @requirement REQ-180-001
 
 mod history_panel;
+mod ime;
 mod render;
 pub mod state;
 
@@ -207,6 +208,106 @@ impl ConversationListView {
             self.state.sidebar_search_results = Some(results);
         }
         cx.notify();
+    }
+
+    /// Read the input text currently owned by the list's active editor.
+    #[must_use]
+    pub fn active_input_text(&self) -> &str {
+        if self.state.conversation_title_editing {
+            &self.state.conversation_title_input
+        } else {
+            &self.state.sidebar_search_query
+        }
+    }
+
+    /// Cursor position for the list's active editor.
+    #[must_use]
+    pub fn active_cursor_position(&self) -> usize {
+        self.active_input_text().len()
+    }
+
+    /// Handle key input when the list owns focus.
+    pub fn handle_key_down(&mut self, event: &gpui::KeyDownEvent, cx: &mut gpui::Context<Self>) {
+        let key = &event.keystroke.key;
+        let modifiers = &event.keystroke.modifiers;
+
+        if modifiers.platform {
+            match key.as_str() {
+                "c" => {
+                    let text = self.active_input_text().to_string();
+                    if !text.is_empty() {
+                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+                    }
+                }
+                "v" => {
+                    if let Some(item) = cx.read_from_clipboard() {
+                        if let Some(text) = item.text() {
+                            self.handle_paste(&text, cx);
+                        }
+                    }
+                }
+                "x" => {
+                    let text = self.active_input_text().to_string();
+                    if !text.is_empty() {
+                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+                    }
+                    if self.state.conversation_title_editing {
+                        self.state.conversation_title_input.clear();
+                        self.state.rename_replace_on_next_char = false;
+                    } else {
+                        self.state.sidebar_search_query.clear();
+                        self.state.sidebar_search_results = None;
+                    }
+                    cx.notify();
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        if self.state.conversation_title_editing {
+            match key.as_str() {
+                "escape" => self.cancel_rename_conversation(cx),
+                "backspace" => self.handle_rename_backspace(cx),
+                "enter" => self.submit_rename_conversation(cx),
+                _ => {}
+            }
+            return;
+        }
+
+        if self.state.sidebar_search_focused {
+            match key.as_str() {
+                "escape" => {
+                    self.state.sidebar_search_focused = false;
+                    if self.state.sidebar_search_query.is_empty() {
+                        self.state.sidebar_search_results = None;
+                    }
+                    cx.notify();
+                }
+                "backspace" => {
+                    self.state.sidebar_search_query.pop();
+                    self.trigger_sidebar_search(cx);
+                    cx.notify();
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Paste text into the list's active editor.
+    pub fn handle_paste(&mut self, text: &str, cx: &mut gpui::Context<Self>) {
+        if self.state.conversation_title_editing {
+            if self.state.rename_replace_on_next_char {
+                self.state.conversation_title_input.clear();
+                self.state.rename_replace_on_next_char = false;
+            }
+            self.state.conversation_title_input.push_str(text);
+            cx.notify();
+        } else if self.state.sidebar_search_focused {
+            self.state.sidebar_search_query.push_str(text);
+            self.trigger_sidebar_search(cx);
+            cx.notify();
+        }
     }
 }
 

--- a/src/ui_gpui/views/conversation_list/render.rs
+++ b/src/ui_gpui/views/conversation_list/render.rs
@@ -11,7 +11,10 @@
 
 use std::collections::HashSet;
 
-use gpui::{div, prelude::*, px, AnyElement, FontWeight, MouseButton, SharedString};
+use gpui::{
+    canvas, div, prelude::*, px, AnyElement, Bounds, ElementInputHandler, FontWeight, MouseButton,
+    Pixels, SharedString,
+};
 use uuid::Uuid;
 
 use super::{ConversationListMode, ConversationListView};
@@ -79,8 +82,10 @@ impl ConversationListView {
                     })
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|this, _, _window, cx| {
+                        cx.listener(|this, _, window, cx| {
+                            cx.stop_propagation();
                             this.state.sidebar_search_focused = true;
+                            window.focus(&this.focus_handle, cx);
                             cx.notify();
                         }),
                     ),
@@ -510,6 +515,32 @@ impl gpui::Render for ConversationListView {
             .bg(bg)
             .flex()
             .flex_col()
+            .track_focus(&self.focus_handle)
+            .child(
+                canvas(
+                    |bounds, _window: &mut gpui::Window, _cx: &mut gpui::App| bounds,
+                    {
+                        let entity = cx.entity();
+                        let focus = self.focus_handle.clone();
+                        move |bounds: Bounds<Pixels>,
+                              _,
+                              window: &mut gpui::Window,
+                              cx: &mut gpui::App| {
+                            window.handle_input(
+                                &focus,
+                                ElementInputHandler::new(bounds, entity),
+                                cx,
+                            );
+                        }
+                    },
+                )
+                .size_0(),
+            )
+            .on_key_down(
+                cx.listener(|this, event: &gpui::KeyDownEvent, _window, cx| {
+                    this.handle_key_down(event, cx);
+                }),
+            )
             .child(self.render_header(cx))
             .child(self.render_list(cx))
     }

--- a/src/ui_gpui/views/conversation_list/tests.rs
+++ b/src/ui_gpui/views/conversation_list/tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 use flume;
-use gpui::{AppContext, TestAppContext};
+use gpui::{AppContext, EntityInputHandler, TestAppContext};
 use uuid::Uuid;
 
 use super::{ConversationListMode, ConversationListView};
@@ -201,4 +201,56 @@ async fn apply_search_results_stores_them(cx: &mut TestAppContext) {
             .unwrap()
             .is_empty());
     });
+}
+
+#[gpui::test]
+async fn list_input_handler_types_into_focused_search(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| ConversationListView::new(ConversationListMode::FullPanel, cx));
+    let mut visual_cx = cx.add_empty_window().clone();
+
+    visual_cx.update(|window, app| {
+        view.update(app, |view, cx| {
+            view.set_bridge(Arc::clone(&bridge));
+            view.state.sidebar_search_focused = true;
+            view.replace_text_in_range(None, "hist", window, cx);
+            assert_eq!(view.state.sidebar_search_query, "hist");
+        });
+    });
+
+    let event = user_rx.recv().expect("expected SearchConversations event");
+    assert!(
+        matches!(event, UserEvent::SearchConversations { ref query } if query == "hist"),
+        "got {event:?}"
+    );
+}
+
+#[gpui::test]
+async fn list_input_handler_supports_backspace_and_escape_for_search(cx: &mut TestAppContext) {
+    let (bridge, user_rx) = make_bridge();
+    let view = cx.new(|cx| ConversationListView::new(ConversationListMode::FullPanel, cx));
+
+    view.update(cx, |view, cx| {
+        view.set_bridge(Arc::clone(&bridge));
+        view.state.sidebar_search_focused = true;
+        view.state.sidebar_search_query = "history".to_string();
+        view.handle_key_down(&key_event("backspace"), cx);
+        assert_eq!(view.state.sidebar_search_query, "histor");
+        view.handle_key_down(&key_event("escape"), cx);
+        assert!(!view.state.sidebar_search_focused);
+    });
+
+    let event = user_rx.recv().expect("expected SearchConversations event");
+    assert!(
+        matches!(event, UserEvent::SearchConversations { ref query } if query == "histor"),
+        "got {event:?}"
+    );
+}
+
+fn key_event(key: &str) -> gpui::KeyDownEvent {
+    gpui::KeyDownEvent {
+        keystroke: gpui::Keystroke::parse(key).unwrap_or_else(|_| panic!("{key} keystroke")),
+        is_held: false,
+        prefer_character_input: false,
+    }
 }

--- a/src/ui_gpui/views/main_panel/command.rs
+++ b/src/ui_gpui/views/main_panel/command.rs
@@ -67,7 +67,6 @@ impl MainPanel {
             ConversationSearchResults { results } => {
                 self.forward_conversation_search_results(results, cx);
             }
-
             ErrorLogExportCompleted { .. } => self.forward_to_error_log(cmd, cx),
 
             // ── settings-only forwarding ─────────────────────────────

--- a/src/ui_gpui/views/main_panel/command.rs
+++ b/src/ui_gpui/views/main_panel/command.rs
@@ -62,8 +62,11 @@ impl MainPanel {
             | ShowConversationExportFormat { .. }
             | ExportCompleted { .. }
             | ToolApprovalRequest { .. }
-            | ToolApprovalResolved { .. }
-            | ConversationSearchResults { .. } => self.forward_to_chat(cmd, cx),
+            | ToolApprovalResolved { .. } => self.forward_to_chat(cmd, cx),
+
+            ConversationSearchResults { results } => {
+                self.forward_conversation_search_results(results, cx);
+            }
 
             ErrorLogExportCompleted { .. } => self.forward_to_error_log(cmd, cx),
 
@@ -143,6 +146,28 @@ impl MainPanel {
         if let Some(ref chat) = self.chat_view {
             chat.update(cx, |view, cx| {
                 view.handle_command(cmd, cx);
+            });
+        }
+    }
+
+    fn forward_conversation_search_results(
+        &self,
+        results: Vec<crate::presentation::view_command::ConversationSearchResult>,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if let Some(ref chat) = self.chat_view {
+            chat.update(cx, |view, cx| {
+                view.handle_command(
+                    ViewCommand::ConversationSearchResults {
+                        results: results.clone(),
+                    },
+                    cx,
+                );
+            });
+        }
+        if let Some(ref history_panel) = self.history_panel {
+            history_panel.update(cx, |view, cx| {
+                view.apply_search_results(results, cx);
             });
         }
     }

--- a/src/ui_gpui/views/main_panel/tests.rs
+++ b/src/ui_gpui/views/main_panel/tests.rs
@@ -186,6 +186,56 @@ async fn ensure_store_subscription_only_subscribes_once_and_applies_published_up
     });
 }
 
+#[gpui::test]
+async fn conversation_search_results_update_history_panel(cx: &mut TestAppContext) {
+    let (app_state, _user_rx, first_conversation_id, _second_conversation_id, _selected_profile_id) =
+        build_app_state();
+    cx.set_global(app_state);
+
+    let panel = cx.new(MainPanel::new);
+
+    panel.update(cx, |panel: &mut MainPanel, cx| {
+        panel.init(cx);
+        let history_panel = panel
+            .history_panel
+            .as_ref()
+            .expect("history panel initialized")
+            .clone();
+        history_panel.update(cx, |view, cx| {
+            view.list_entity().update(cx, |list, _cx| {
+                list.state.sidebar_search_query = "start".to_string();
+            });
+        });
+
+        panel.handle_command(
+            ViewCommand::ConversationSearchResults {
+                results: vec![
+                    crate::presentation::view_command::ConversationSearchResult {
+                        id: first_conversation_id,
+                        title: "Startup Conversation".to_string(),
+                        is_title_match: true,
+                        match_context: "Startup".to_string(),
+                        message_count: 2,
+                        updated_at: chrono::Utc::now(),
+                    },
+                ],
+            },
+            cx,
+        );
+
+        history_panel.read_with(cx, |view, cx| {
+            let list = view.list_entity().read(cx);
+            let results = list
+                .state
+                .sidebar_search_results
+                .as_ref()
+                .expect("history panel should receive search results");
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].id, first_conversation_id);
+        });
+    });
+}
+
 fn remote_model(
     provider_id: &str,
     model_id: &str,


### PR DESCRIPTION
## Summary

Fixes the History panel search box after the ConversationList refactor.

The embedded ConversationListView could visually focus the search box in FullPanel mode, but typed input was not routed into the list because only ChatView owned an input handler. This made History search clickable but not typeable.

## Changes

- Add EntityInputHandler support to ConversationListView so it can own search and rename text input directly.
- Register the list focus handle and input bounds from ConversationListView render.
- Focus the list and stop click propagation when the search box is clicked, preventing MainPanel from stealing focus back.
- Make HistoryPanelView expose the embedded list focus handle.
- Forward ConversationSearchResults to both ChatView and HistoryPanelView.
- Add tests for FullPanel search typing, search key handling, and History panel search-result delivery.

## Verification

- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test --lib
- targeted History/search integration tests

Fixes #180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactors**
  * Consolidated conversation list UI into a shared component used by both sidebar and history panel for improved consistency
  * Improved sidebar search state management and focus handling with context-aware methods
  * Updated IME input handling for better text editing support in search and rename workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->