### PR TITLE
Scroll selected conversations to latest message (Fixes #188)

### DIFF
--- a/.github/workflows/pr-quality-and-e2e.yml
+++ b/.github/workflows/pr-quality-and-e2e.yml
@@ -72,6 +72,9 @@ jobs:
             -D clippy::type_complexity \
             -D clippy::struct_excessive_bools
 
+      - name: Clear lint artifacts before tests
+        run: cargo clean
+
       - name: Run library and integration tests
         run: cargo test --lib --tests
 

--- a/src/ui_gpui/views/chat_view/mod.rs
+++ b/src/ui_gpui/views/chat_view/mod.rs
@@ -132,6 +132,45 @@ impl ChatView {
         }
     }
 
+    fn reset_autoscroll_if_needed(
+        &mut self,
+        should_reset_autoscroll: bool,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if should_reset_autoscroll {
+            self.state.chat_autoscroll_enabled = true;
+            self.chat_scroll_handle.scroll_to_bottom();
+            self.maybe_scroll_chat_to_bottom(cx);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn scroll_after_loaded_messages_if_needed(
+        &self,
+        previous_conversation_id: Option<Uuid>,
+        selected_conversation_id: Option<Uuid>,
+        previous_selection_generation: u64,
+        previous_messages_empty: bool,
+        was_streaming: bool,
+        streaming: &StreamingStoreSnapshot,
+        should_reset_autoscroll: bool,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if !should_reset_autoscroll
+            && self.state.chat_autoscroll_enabled
+            && previous_conversation_id == selected_conversation_id
+            && previous_selection_generation == self.selection_generation
+            && previous_messages_empty
+            && !self.state.messages.is_empty()
+            && !was_streaming
+            && streaming.active_target.is_none()
+            && streaming.stream_buffer.is_empty()
+            && streaming.thinking_buffer.is_empty()
+        {
+            self.maybe_scroll_chat_to_bottom(cx);
+        }
+    }
+
     /// @plan PLAN-20260304-GPUIREMEDIATE.P05
     /// @plan PLAN-20260407-ISSUE172.P07 (cache priming)
     pub(super) fn messages_from_payload(
@@ -247,6 +286,7 @@ impl ChatView {
 
         let previous_conversation_id = self.conversation_id;
         let previous_selection_generation = self.selection_generation;
+        let previous_messages_empty = self.state.messages.is_empty();
 
         self.state.conversations = conversations;
         self.state.active_conversation_id = selected_conversation_id;
@@ -280,11 +320,9 @@ impl ChatView {
             }
         };
 
-        if should_reset_autoscroll {
-            self.state.chat_autoscroll_enabled = true;
-            self.chat_scroll_handle.scroll_to_bottom();
-            self.maybe_scroll_chat_to_bottom(cx);
-        }
+        self.reset_autoscroll_if_needed(should_reset_autoscroll, cx);
+
+        let was_streaming = matches!(self.state.streaming, StreamingState::Streaming { .. });
 
         // The store now guarantees that `snapshot.chat.transcript` is always
         // scoped to the currently selected conversation: it is cleared on
@@ -293,8 +331,17 @@ impl ChatView {
         // render the previous conversation's messages during a
         // selection -> Loading -> Ready transition.
         self.state.messages = Self::messages_from_payload(transcript);
+        self.scroll_after_loaded_messages_if_needed(
+            previous_conversation_id,
+            selected_conversation_id,
+            previous_selection_generation,
+            previous_messages_empty,
+            was_streaming,
+            &streaming,
+            should_reset_autoscroll,
+            cx,
+        );
 
-        let was_streaming = matches!(self.state.streaming, StreamingState::Streaming { .. });
         let was_thinking = self
             .state
             .thinking_content

--- a/src/ui_gpui/views/chat_view/mod.rs
+++ b/src/ui_gpui/views/chat_view/mod.rs
@@ -132,15 +132,9 @@ impl ChatView {
         }
     }
 
-    fn reset_autoscroll_if_needed(
-        &mut self,
-        should_reset_autoscroll: bool,
-        cx: &mut gpui::Context<Self>,
-    ) {
+    const fn reset_autoscroll_if_needed(&mut self, should_reset_autoscroll: bool) {
         if should_reset_autoscroll {
             self.state.chat_autoscroll_enabled = true;
-            self.chat_scroll_handle.scroll_to_bottom();
-            self.maybe_scroll_chat_to_bottom(cx);
         }
     }
 
@@ -156,16 +150,16 @@ impl ChatView {
         should_reset_autoscroll: bool,
         cx: &mut gpui::Context<Self>,
     ) {
-        if !should_reset_autoscroll
-            && self.state.chat_autoscroll_enabled
-            && previous_conversation_id == selected_conversation_id
+        let loaded_messages_scroll = previous_conversation_id == selected_conversation_id
             && previous_selection_generation == self.selection_generation
             && previous_messages_empty
             && !self.state.messages.is_empty()
             && !was_streaming
             && streaming.active_target.is_none()
             && streaming.stream_buffer.is_empty()
-            && streaming.thinking_buffer.is_empty()
+            && streaming.thinking_buffer.is_empty();
+
+        if self.state.chat_autoscroll_enabled && (should_reset_autoscroll || loaded_messages_scroll)
         {
             self.maybe_scroll_chat_to_bottom(cx);
         }
@@ -320,7 +314,7 @@ impl ChatView {
             }
         };
 
-        self.reset_autoscroll_if_needed(should_reset_autoscroll, cx);
+        self.reset_autoscroll_if_needed(should_reset_autoscroll);
 
         let was_streaming = matches!(self.state.streaming, StreamingState::Streaming { .. });
 

--- a/src/ui_gpui/views/chat_view/mod_tests.rs
+++ b/src/ui_gpui/views/chat_view/mod_tests.rs
@@ -227,6 +227,89 @@ async fn home_pageup_pagedown_and_end_keys_control_chat_scroll_autoscroll(cx: &m
 }
 
 #[gpui::test]
+async fn apply_store_snapshot_selected_conversation_ready_scrolls_after_messages_load(
+    cx: &mut TestAppContext,
+) {
+    let view = cx.new(|cx| ChatView::new(ChatState::default(), cx));
+    let mut visual_cx = cx.add_empty_window().clone();
+
+    visual_cx.update(|_window, app| {
+        view.update(app, |view: &mut ChatView, cx| {
+            let previous_conversation_id = Uuid::new_v4();
+            let selected_conversation_id = Uuid::new_v4();
+            let selected_summary = ConversationSummary {
+                id: selected_conversation_id,
+                title: "Long conversation".to_string(),
+                updated_at: Utc::now(),
+                message_count: 2,
+                preview: Some("latest reply".to_string()),
+            };
+
+            view.conversation_id = Some(previous_conversation_id);
+            view.selection_generation = 7;
+            view.state.chat_autoscroll_enabled = false;
+            view.maybe_scroll_chat_to_bottom_invocations.set(0);
+
+            view.apply_store_snapshot(
+                ChatStoreSnapshot {
+                    selected_conversation_id: Some(selected_conversation_id),
+                    selected_conversation_title: "Long conversation".to_string(),
+                    selection_generation: 8,
+                    load_state: ConversationLoadState::Loading {
+                        conversation_id: selected_conversation_id,
+                        generation: 8,
+                    },
+                    transcript: Vec::new(),
+                    streaming: StreamingStoreSnapshot::default(),
+                    conversations: vec![selected_summary.clone()],
+                },
+                cx,
+            );
+
+            assert!(view.state.chat_autoscroll_enabled);
+            assert_eq!(view.maybe_scroll_chat_to_bottom_invocations.get(), 1);
+            assert!(view.state.messages.is_empty());
+
+            let loaded_messages = vec![
+                ConversationMessagePayload {
+                    role: MessageRole::User,
+                    content: "beginning".to_string(),
+                    thinking_content: None,
+                    timestamp: None,
+                    model_id: None,
+                },
+                ConversationMessagePayload {
+                    role: MessageRole::Assistant,
+                    content: "latest reply".to_string(),
+                    thinking_content: None,
+                    timestamp: None,
+                    model_id: Some("gpt-5.5".to_string()),
+                },
+            ];
+
+            view.apply_store_snapshot(
+                ChatStoreSnapshot {
+                    selected_conversation_id: Some(selected_conversation_id),
+                    selected_conversation_title: "Long conversation".to_string(),
+                    selection_generation: 8,
+                    load_state: ConversationLoadState::Ready {
+                        conversation_id: selected_conversation_id,
+                        generation: 8,
+                    },
+                    transcript: loaded_messages,
+                    streaming: StreamingStoreSnapshot::default(),
+                    conversations: vec![selected_summary],
+                },
+                cx,
+            );
+
+            assert_eq!(view.state.messages.len(), 2);
+            assert_eq!(view.maybe_scroll_chat_to_bottom_invocations.get(), 2);
+        });
+    });
+}
+
+#[gpui::test]
 async fn apply_store_snapshot_streaming_calls_maybe_scroll_when_autoscroll_enabled(
     cx: &mut TestAppContext,
 ) {

--- a/src/ui_gpui/views/chat_view/mod_tests.rs
+++ b/src/ui_gpui/views/chat_view/mod_tests.rs
@@ -226,6 +226,88 @@ async fn home_pageup_pagedown_and_end_keys_control_chat_scroll_autoscroll(cx: &m
     });
 }
 
+fn conversation_ready_scroll_fixture() -> (
+    Uuid,
+    ConversationSummary,
+    impl Fn() -> Vec<ConversationMessagePayload>,
+) {
+    let selected_conversation_id = Uuid::new_v4();
+    let selected_summary = ConversationSummary {
+        id: selected_conversation_id,
+        title: "Long conversation".to_string(),
+        updated_at: Utc::now(),
+        message_count: 2,
+        preview: Some("latest reply".to_string()),
+    };
+    let loaded_messages = || {
+        vec![
+            ConversationMessagePayload {
+                role: MessageRole::User,
+                content: "beginning".to_string(),
+                thinking_content: None,
+                timestamp: None,
+                model_id: None,
+            },
+            ConversationMessagePayload {
+                role: MessageRole::Assistant,
+                content: "latest reply".to_string(),
+                thinking_content: None,
+                timestamp: None,
+                model_id: Some("gpt-5.5".to_string()),
+            },
+        ]
+    };
+
+    (selected_conversation_id, selected_summary, loaded_messages)
+}
+
+fn apply_loading_snapshot_for_scroll_test(
+    view: &mut ChatView,
+    cx: &mut gpui::Context<ChatView>,
+    selected_conversation_id: Uuid,
+    selected_summary: ConversationSummary,
+) {
+    view.apply_store_snapshot(
+        ChatStoreSnapshot {
+            selected_conversation_id: Some(selected_conversation_id),
+            selected_conversation_title: "Long conversation".to_string(),
+            selection_generation: 8,
+            load_state: ConversationLoadState::Loading {
+                conversation_id: selected_conversation_id,
+                generation: 8,
+            },
+            transcript: Vec::new(),
+            streaming: StreamingStoreSnapshot::default(),
+            conversations: vec![selected_summary],
+        },
+        cx,
+    );
+}
+
+fn apply_ready_snapshot_for_scroll_test(
+    view: &mut ChatView,
+    cx: &mut gpui::Context<ChatView>,
+    selected_conversation_id: Uuid,
+    selected_summary: ConversationSummary,
+    messages: Vec<ConversationMessagePayload>,
+) {
+    view.apply_store_snapshot(
+        ChatStoreSnapshot {
+            selected_conversation_id: Some(selected_conversation_id),
+            selected_conversation_title: "Long conversation".to_string(),
+            selection_generation: 8,
+            load_state: ConversationLoadState::Ready {
+                conversation_id: selected_conversation_id,
+                generation: 8,
+            },
+            transcript: messages,
+            streaming: StreamingStoreSnapshot::default(),
+            conversations: vec![selected_summary],
+        },
+        cx,
+    );
+}
+
 #[gpui::test]
 async fn apply_store_snapshot_selected_conversation_ready_scrolls_after_messages_load(
     cx: &mut TestAppContext,
@@ -236,73 +318,62 @@ async fn apply_store_snapshot_selected_conversation_ready_scrolls_after_messages
     visual_cx.update(|_window, app| {
         view.update(app, |view: &mut ChatView, cx| {
             let previous_conversation_id = Uuid::new_v4();
-            let selected_conversation_id = Uuid::new_v4();
-            let selected_summary = ConversationSummary {
-                id: selected_conversation_id,
-                title: "Long conversation".to_string(),
-                updated_at: Utc::now(),
-                message_count: 2,
-                preview: Some("latest reply".to_string()),
-            };
+            let (selected_conversation_id, selected_summary, loaded_messages) =
+                conversation_ready_scroll_fixture();
 
             view.conversation_id = Some(previous_conversation_id);
             view.selection_generation = 7;
             view.state.chat_autoscroll_enabled = false;
             view.maybe_scroll_chat_to_bottom_invocations.set(0);
 
-            view.apply_store_snapshot(
-                ChatStoreSnapshot {
-                    selected_conversation_id: Some(selected_conversation_id),
-                    selected_conversation_title: "Long conversation".to_string(),
-                    selection_generation: 8,
-                    load_state: ConversationLoadState::Loading {
-                        conversation_id: selected_conversation_id,
-                        generation: 8,
-                    },
-                    transcript: Vec::new(),
-                    streaming: StreamingStoreSnapshot::default(),
-                    conversations: vec![selected_summary.clone()],
-                },
+            apply_loading_snapshot_for_scroll_test(
+                view,
                 cx,
+                selected_conversation_id,
+                selected_summary.clone(),
             );
 
             assert!(view.state.chat_autoscroll_enabled);
             assert_eq!(view.maybe_scroll_chat_to_bottom_invocations.get(), 1);
             assert!(view.state.messages.is_empty());
 
-            let loaded_messages = vec![
-                ConversationMessagePayload {
-                    role: MessageRole::User,
-                    content: "beginning".to_string(),
-                    thinking_content: None,
-                    timestamp: None,
-                    model_id: None,
-                },
-                ConversationMessagePayload {
-                    role: MessageRole::Assistant,
-                    content: "latest reply".to_string(),
-                    thinking_content: None,
-                    timestamp: None,
-                    model_id: Some("gpt-5.5".to_string()),
-                },
-            ];
-
-            view.apply_store_snapshot(
-                ChatStoreSnapshot {
-                    selected_conversation_id: Some(selected_conversation_id),
-                    selected_conversation_title: "Long conversation".to_string(),
-                    selection_generation: 8,
-                    load_state: ConversationLoadState::Ready {
-                        conversation_id: selected_conversation_id,
-                        generation: 8,
-                    },
-                    transcript: loaded_messages,
-                    streaming: StreamingStoreSnapshot::default(),
-                    conversations: vec![selected_summary],
-                },
+            apply_ready_snapshot_for_scroll_test(
+                view,
                 cx,
+                selected_conversation_id,
+                selected_summary.clone(),
+                loaded_messages(),
             );
 
+            assert_eq!(view.state.messages.len(), 2);
+            assert_eq!(view.maybe_scroll_chat_to_bottom_invocations.get(), 2);
+
+            view.conversation_id = Some(selected_conversation_id);
+            view.selection_generation = 0;
+            view.state.messages.clear();
+            view.state.chat_autoscroll_enabled = false;
+            view.maybe_scroll_chat_to_bottom_invocations.set(0);
+
+            apply_loading_snapshot_for_scroll_test(
+                view,
+                cx,
+                selected_conversation_id,
+                selected_summary.clone(),
+            );
+
+            assert!(view.state.chat_autoscroll_enabled);
+            assert_eq!(view.maybe_scroll_chat_to_bottom_invocations.get(), 1);
+            assert!(view.state.messages.is_empty());
+
+            apply_ready_snapshot_for_scroll_test(
+                view,
+                cx,
+                selected_conversation_id,
+                selected_summary,
+                loaded_messages(),
+            );
+
+            assert!(view.state.chat_autoscroll_enabled);
             assert_eq!(view.state.messages.len(), 2);
             assert_eq!(view.maybe_scroll_chat_to_bottom_invocations.get(), 2);
         });


### PR DESCRIPTION
## Summary
- scroll selected/restored conversations again after replayed messages populate the chat view
- preserve existing streaming autoscroll behavior and avoid duplicate finalization scrolls
- add a GPUI regression test for the loading-to-ready selected conversation path

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --tests
- python3 -m lizard -C 50 -L 100 -w src/ --exclude "src/main_gpui.rs" --exclude "src/bin/*" --exclude "src/services/chat.rs" --exclude "src/llm/client_agent.rs"

Fixes #188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autoscroll reliability in chat conversations when loading messages.
  * Enhanced chat view updates during conversation state transitions to prevent scroll misalignment.

* **Tests**
  * Added test coverage for message loading transitions in conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->