### PR TITLE
Support multiline chat composer shortcuts (Fixes #190)

### DIFF
--- a/src/ui_gpui/views/chat_view/mod.rs
+++ b/src/ui_gpui/views/chat_view/mod.rs
@@ -775,7 +775,7 @@ impl ChatView {
         modifiers: gpui::Modifiers,
         cx: &mut gpui::Context<Self>,
     ) {
-        if modifiers.shift || modifiers.control {
+        if modifiers.shift || modifiers.control || modifiers.alt {
             self.insert_composer_newline(cx);
         } else {
             self.handle_enter(cx);

--- a/src/ui_gpui/views/chat_view/mod.rs
+++ b/src/ui_gpui/views/chat_view/mod.rs
@@ -763,6 +763,26 @@ impl ChatView {
             cx.notify();
             return;
         }
+        self.insert_composer_text(text, cx);
+    }
+
+    pub(super) fn insert_composer_newline(&mut self, cx: &mut gpui::Context<Self>) {
+        self.insert_composer_text("\n", cx);
+    }
+
+    pub(super) fn handle_composer_enter(
+        &mut self,
+        modifiers: gpui::Modifiers,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if modifiers.shift || modifiers.control {
+            self.insert_composer_newline(cx);
+        } else {
+            self.handle_enter(cx);
+        }
+    }
+
+    fn insert_composer_text(&mut self, text: &str, cx: &mut gpui::Context<Self>) {
         if self.state.conversation_dropdown_open || self.state.profile_dropdown_open {
             return;
         }

--- a/src/ui_gpui/views/chat_view/mod_tests.rs
+++ b/src/ui_gpui/views/chat_view/mod_tests.rs
@@ -95,6 +95,16 @@ fn chat_key_event(key: &str) -> KeyDownEvent {
     }
 }
 
+fn modified_chat_key_event(key: &str, modifiers: Modifiers) -> KeyDownEvent {
+    KeyDownEvent {
+        keystroke: Keystroke {
+            modifiers,
+            ..chat_key_event(key).keystroke
+        },
+        ..chat_key_event(key)
+    }
+}
+
 fn make_chat_bridge() -> (Arc<GpuiBridge>, flume::Receiver<UserEvent>) {
     let (user_tx, user_rx) = flume::bounded(8);
     let (_view_tx, view_rx) = flume::bounded(8);
@@ -777,6 +787,86 @@ async fn wheel_scroll_down_reenables_autoscroll_only_when_near_bottom(cx: &mut T
             view.chat_scroll_handle.set_offset(point(px(0.0), px(0.0)));
             view.refresh_autoscroll_state_after_wheel(&downward_event);
             assert!(view.state.chat_autoscroll_enabled);
+        });
+    });
+}
+
+#[gpui::test]
+async fn modified_enter_inserts_newline_without_submitting(cx: &mut TestAppContext) {
+    let view = cx.new(|cx| ChatView::new(ChatState::default(), cx));
+    let mut visual_cx = cx.add_empty_window().clone();
+    let (bridge, user_rx) = make_chat_bridge();
+
+    visual_cx.update(|_window, app| {
+        view.update(app, |view: &mut ChatView, cx| {
+            view.set_bridge(bridge.clone());
+            view.state.input_text = "firstsecond".to_string();
+            view.state.cursor_position = "first".len();
+
+            view.handle_key_down(
+                &modified_chat_key_event(
+                    "enter",
+                    Modifiers {
+                        shift: true,
+                        ..Modifiers::default()
+                    },
+                ),
+                cx,
+            );
+
+            assert_eq!(view.state.input_text, "first\nsecond");
+            assert_eq!(view.state.cursor_position, "first\n".len());
+            assert!(user_rx.try_recv().is_err());
+            assert_eq!(view.state.streaming, StreamingState::Idle);
+
+            view.handle_key_down(
+                &modified_chat_key_event(
+                    "enter",
+                    Modifiers {
+                        control: true,
+                        ..Modifiers::default()
+                    },
+                ),
+                cx,
+            );
+
+            assert_eq!(view.state.input_text, "first\n\nsecond");
+            assert_eq!(view.state.cursor_position, "first\n\n".len());
+            assert!(user_rx.try_recv().is_err());
+            assert_eq!(view.state.streaming, StreamingState::Idle);
+        });
+    });
+}
+
+#[gpui::test]
+async fn plain_enter_still_submits_message(cx: &mut TestAppContext) {
+    let view = cx.new(|cx| ChatView::new(ChatState::default(), cx));
+    let mut visual_cx = cx.add_empty_window().clone();
+    let (bridge, user_rx) = make_chat_bridge();
+
+    visual_cx.update(|_window, app| {
+        view.update(app, |view: &mut ChatView, cx| {
+            view.set_bridge(bridge.clone());
+            view.state.input_text = "send me".to_string();
+            view.state.cursor_position = view.state.input_text.len();
+
+            view.handle_key_down(&chat_key_event("enter"), cx);
+
+            assert_eq!(
+                user_rx.try_recv().ok(),
+                Some(UserEvent::SendMessage {
+                    text: "send me".to_string(),
+                })
+            );
+            assert!(view.state.input_text.is_empty());
+            assert_eq!(view.state.cursor_position, 0);
+            assert_eq!(
+                view.state.streaming,
+                StreamingState::Streaming {
+                    content: String::new(),
+                    done: false,
+                }
+            );
         });
     });
 }

--- a/src/ui_gpui/views/chat_view/mod_tests.rs
+++ b/src/ui_gpui/views/chat_view/mod_tests.rs
@@ -834,6 +834,22 @@ async fn modified_enter_inserts_newline_without_submitting(cx: &mut TestAppConte
             assert_eq!(view.state.cursor_position, "first\n\n".len());
             assert!(user_rx.try_recv().is_err());
             assert_eq!(view.state.streaming, StreamingState::Idle);
+
+            view.handle_key_down(
+                &modified_chat_key_event(
+                    "enter",
+                    Modifiers {
+                        alt: true,
+                        ..Modifiers::default()
+                    },
+                ),
+                cx,
+            );
+
+            assert_eq!(view.state.input_text, "first\n\n\nsecond");
+            assert_eq!(view.state.cursor_position, "first\n\n\n".len());
+            assert!(user_rx.try_recv().is_err());
+            assert_eq!(view.state.streaming, StreamingState::Idle);
         });
     });
 }

--- a/src/ui_gpui/views/chat_view/render.rs
+++ b/src/ui_gpui/views/chat_view/render.rs
@@ -169,7 +169,7 @@ impl ChatView {
             "pageup" => self.scroll_chat_page_up(cx),
             "pagedown" => self.scroll_chat_page_down(cx),
             "backspace" => self.handle_backspace(cx),
-            "enter" => self.handle_enter(cx),
+            "enter" => self.handle_composer_enter(*modifiers, cx),
             "escape" => {
                 if matches!(self.state.streaming, StreamingState::Streaming { .. }) {
                     // @plan PLAN-20260416-ISSUE173.P14-CR7


### PR DESCRIPTION
## Summary

- Adds modified Enter handling for the GPUI chat composer.
- Shift+Enter and Ctrl+Enter now insert a newline at the current cursor position without submitting.
- Plain Enter continues to submit the current message.
- Adds GPUI tests for Shift+Enter, Ctrl+Enter, and plain Enter behavior.

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --tests -- --format terse
- .venv-lizard/bin/lizard -C 50 -L 100 -w touched chat view files

Fixes #190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift+Enter and Ctrl+Enter now insert newlines in the chat input
  * Improved text insertion and paste handling in the composer

* **Tests**
  * Added test coverage for Enter key modifiers (Shift, Control)
  * Added test coverage for message submission and input state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->