### PR TITLE
Prevent empty assistant transcript duplication (Fixes #187)

### DIFF
--- a/src/llm/client_agent.rs
+++ b/src/llm/client_agent.rs
@@ -573,6 +573,7 @@ impl crate::llm::LlmClient {
             message_history.len()
         );
 
+        let history_request_count = message_history.len();
         let options = if message_history.is_empty() {
             RunOptions::default()
         } else {
@@ -591,7 +592,7 @@ impl crate::llm::LlmClient {
         while let Some(event_result) = stream.next().await {
             match event_result {
                 Ok(event) => {
-                    Self::handle_agent_stream_event(event, history_messages.len(), on_event);
+                    Self::handle_agent_stream_event(event, history_request_count, on_event);
                 }
 
                 Err(e) => {

--- a/src/llm/client_agent.rs
+++ b/src/llm/client_agent.rs
@@ -416,6 +416,7 @@ impl AgentClientExt for crate::llm::LlmClient {
 impl crate::llm::LlmClient {
     fn collect_tool_transcript(
         messages: &[ModelRequest],
+        history_request_count: usize,
     ) -> (
         Vec<crate::llm::tools::ToolUse>,
         Vec<crate::llm::tools::ToolResult>,
@@ -423,7 +424,7 @@ impl crate::llm::LlmClient {
         let mut tool_calls = Vec::new();
         let mut tool_results = Vec::new();
 
-        for request in messages {
+        for request in messages.iter().skip(history_request_count) {
             for part in &request.parts {
                 match part {
                     ModelRequestPart::ModelResponse(response) => {
@@ -490,8 +491,11 @@ impl crate::llm::LlmClient {
         });
     }
 
-    fn handle_agent_stream_event<F>(event: AgentStreamEvent, on_event: &mut F)
-    where
+    fn handle_agent_stream_event<F>(
+        event: AgentStreamEvent,
+        history_request_count: usize,
+        on_event: &mut F,
+    ) where
         F: FnMut(StreamEvent) + Send,
     {
         match event {
@@ -529,7 +533,8 @@ impl crate::llm::LlmClient {
             }
             AgentStreamEvent::RunComplete { messages, .. } => {
                 tracing::info!("run_agent_stream: RunComplete");
-                let (tool_calls, tool_results) = Self::collect_tool_transcript(&messages);
+                let (tool_calls, tool_results) =
+                    Self::collect_tool_transcript(&messages, history_request_count);
                 on_event(StreamEvent::ToolTranscript {
                     tool_calls,
                     tool_results,
@@ -585,7 +590,9 @@ impl crate::llm::LlmClient {
 
         while let Some(event_result) = stream.next().await {
             match event_result {
-                Ok(event) => Self::handle_agent_stream_event(event, on_event),
+                Ok(event) => {
+                    Self::handle_agent_stream_event(event, history_messages.len(), on_event);
+                }
 
                 Err(e) => {
                     let err_msg = debug_error_message(&e);

--- a/src/llm/client_agent/tests.rs
+++ b/src/llm/client_agent/tests.rs
@@ -191,11 +191,14 @@ fn collect_tool_transcript_extracts_calls_and_results() {
         ToolReturnPart::error("web_search", "request failed").with_tool_call_id("tool-call-2"),
     ));
 
-    let (tool_calls, tool_results) = crate::llm::LlmClient::collect_tool_transcript(&[
-        request_with_tool_call,
-        request_with_tool_return,
-        request_with_tool_error,
-    ]);
+    let (tool_calls, tool_results) = crate::llm::LlmClient::collect_tool_transcript(
+        &[
+            request_with_tool_call,
+            request_with_tool_return,
+            request_with_tool_error,
+        ],
+        0,
+    );
 
     assert_eq!(tool_calls.len(), 1);
     assert_eq!(tool_calls[0].id, "tool-call-1");
@@ -248,6 +251,62 @@ fn build_agent_message_history_preserves_assistant_tool_results() {
         }
         other => panic!("expected second tool return part, got {other:?}"),
     }
+}
+
+#[test]
+fn collect_tool_transcript_skips_existing_history() {
+    let mut historical_response = ModelResponse::new();
+    historical_response.add_part(ModelResponsePart::ToolCall(
+        ToolCallPart::new(
+            "web_search",
+            ToolCallArgs::json(serde_json::json!({"query":"old"})),
+        )
+        .with_tool_call_id("historical-tool-call"),
+    ));
+
+    let mut history_with_tool_call = ModelRequest::new();
+    history_with_tool_call.add_part(ModelRequestPart::ModelResponse(Box::new(
+        historical_response,
+    )));
+
+    let mut history_with_tool_return = ModelRequest::new();
+    history_with_tool_return.add_part(ModelRequestPart::ToolReturn(
+        ToolReturnPart::success("web_search", "old result")
+            .with_tool_call_id("historical-tool-call"),
+    ));
+
+    let mut current_response = ModelResponse::new();
+    current_response.add_part(ModelResponsePart::ToolCall(
+        ToolCallPart::new(
+            "web_search",
+            ToolCallArgs::json(serde_json::json!({"query":"new"})),
+        )
+        .with_tool_call_id("current-tool-call"),
+    ));
+
+    let mut current_tool_call = ModelRequest::new();
+    current_tool_call.add_part(ModelRequestPart::ModelResponse(Box::new(current_response)));
+
+    let mut current_tool_return = ModelRequest::new();
+    current_tool_return.add_part(ModelRequestPart::ToolReturn(
+        ToolReturnPart::success("web_search", "new result").with_tool_call_id("current-tool-call"),
+    ));
+
+    let (tool_calls, tool_results) = crate::llm::LlmClient::collect_tool_transcript(
+        &[
+            history_with_tool_call,
+            history_with_tool_return,
+            current_tool_call,
+            current_tool_return,
+        ],
+        2,
+    );
+
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].id, "current-tool-call");
+    assert_eq!(tool_results.len(), 1);
+    assert_eq!(tool_results[0].tool_use_id, "current-tool-call");
+    assert_eq!(tool_results[0].content, "new result");
 }
 
 /// @plan PLAN-20260416-ISSUE173.P06

--- a/src/llm/client_agent/tests.rs
+++ b/src/llm/client_agent/tests.rs
@@ -306,7 +306,59 @@ fn collect_tool_transcript_skips_existing_history() {
     assert_eq!(tool_calls[0].id, "current-tool-call");
     assert_eq!(tool_results.len(), 1);
     assert_eq!(tool_results[0].tool_use_id, "current-tool-call");
+
     assert_eq!(tool_results[0].content, "new result");
+}
+#[test]
+fn collect_tool_transcript_uses_built_history_request_count_not_message_count() {
+    let mut system_message = Message::system("system prompt");
+    system_message.tool_results = vec![crate::llm::tools::ToolResult::success(
+        "ignored-system-tool",
+        "ignored",
+    )];
+
+    let empty_assistant = Message::assistant("");
+    let historical_assistant =
+        Message::assistant("tool summary").with_tool_uses(vec![crate::llm::tools::ToolUse::new(
+            "historical-tool-call",
+            "web_search",
+            serde_json::json!({"query":"old"}),
+        )]);
+
+    let history_messages = [system_message, empty_assistant, historical_assistant];
+    let message_history = crate::llm::LlmClient::build_agent_message_history(&history_messages);
+
+    assert_eq!(history_messages.len(), 3);
+    assert_eq!(message_history.len(), 1);
+
+    let mut current_response = ModelResponse::new();
+    current_response.add_part(ModelResponsePart::ToolCall(
+        ToolCallPart::new(
+            "web_search",
+            ToolCallArgs::json(serde_json::json!({"query":"new"})),
+        )
+        .with_tool_call_id("current-tool-call"),
+    ));
+
+    let mut current_tool_call = ModelRequest::new();
+    current_tool_call.add_part(ModelRequestPart::ModelResponse(Box::new(current_response)));
+
+    let mut current_tool_return = ModelRequest::new();
+    current_tool_return.add_part(ModelRequestPart::ToolReturn(
+        ToolReturnPart::success("web_search", "new result").with_tool_call_id("current-tool-call"),
+    ));
+
+    let mut run_complete_messages = message_history;
+    run_complete_messages.push(current_tool_call);
+    run_complete_messages.push(current_tool_return);
+
+    let (tool_calls, tool_results) =
+        crate::llm::LlmClient::collect_tool_transcript(&run_complete_messages, 1);
+
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].id, "current-tool-call");
+    assert_eq!(tool_results.len(), 1);
+    assert_eq!(tool_results[0].tool_use_id, "current-tool-call");
 }
 
 /// @plan PLAN-20260416-ISSUE173.P06

--- a/src/services/chat_impl/streaming.rs
+++ b/src/services/chat_impl/streaming.rs
@@ -289,11 +289,15 @@ pub(super) async fn persist_assistant_response(
     tool_results: &[crate::llm::tools::ToolResult],
     model_label: &str,
 ) {
-    if response_text.is_empty()
-        && thinking_text.is_empty()
-        && tool_calls.is_empty()
-        && tool_results.is_empty()
-    {
+    if response_text.is_empty() && thinking_text.is_empty() {
+        if !tool_calls.is_empty() || !tool_results.is_empty() {
+            tracing::warn!(
+                conversation_id = %conversation_id,
+                tool_calls = tool_calls.len(),
+                tool_results = tool_results.len(),
+                "Skipping assistant response with tool transcript but no assistant-visible output"
+            );
+        }
         return;
     }
 

--- a/src/services/chat_impl/tests.rs
+++ b/src/services/chat_impl/tests.rs
@@ -508,6 +508,39 @@ async fn test_send_message() {
 }
 
 #[tokio::test]
+async fn persist_assistant_response_skips_empty_turn_with_only_tool_transcript() {
+    let conversation_service_impl = Arc::new(MockConversationService::new(Uuid::new_v4()));
+    let conversation_service =
+        conversation_service_impl.clone() as Arc<dyn super::super::ConversationService>;
+    let conversation_id = Uuid::new_v4();
+    let tool_calls = vec![crate::llm::tools::ToolUse::new(
+        "historical-tool-call",
+        "web_search",
+        serde_json::json!({"query":"old"}),
+    )];
+    let tool_results = vec![crate::llm::tools::ToolResult::success(
+        "historical-tool-call",
+        "old result",
+    )];
+
+    streaming::persist_assistant_response(
+        &conversation_service,
+        conversation_id,
+        "",
+        "",
+        &tool_calls,
+        &tool_results,
+        "Test Profile",
+    )
+    .await;
+
+    assert!(
+        conversation_service_impl.messages.read().await.is_empty(),
+        "empty assistant turns must not persist historical tool transcript"
+    );
+}
+
+#[tokio::test]
 async fn support_app_settings_services_cover_success_and_failure_paths() {
     let in_memory = InMemoryAppSettingsService::new();
     let profile_id = Uuid::new_v4();


### PR DESCRIPTION
## Summary

- Scope RunComplete tool transcript collection to requests added during the current turn
- Skip persisting assistant rows when response and thinking text are both empty, even if a suspicious tool transcript is present
- Add regressions for historical transcript filtering and empty transcript-only assistant persistence

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib
- cargo test --tests -- --format terse
- ./.venv-lizard/bin/lizard -C 20 src/llm/client_agent.rs src/services/chat_impl/streaming.rs src/llm/client_agent/tests.rs src/services/chat_impl/tests.rs

Fixes #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool transcripts are now correctly scoped to current interactions, excluding historical message requests
  * Improved handling of assistant responses containing tool execution data without visible message content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->