### PR TITLE
Revise walkthrough for general assistant use (Fixes #198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The Linux tray uses the StatusNotifierItem protocol. KDE Plasma supports it out 
 4. Choose a provider/model, enter your API key, and save the profile.
 5. Select the profile in the chat panel and send a message.
 
-For a complete setup guide, including a Z.ai GLM-5.1 coding profile example, see [docs/walkthrough.md](docs/walkthrough.md).
+For a complete setup guide and user documentation for skills and MCP tools, see the [docs index](docs/README.md).
 
 ## Where settings are stored
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Personal Agent documentation
+
+Personal Agent is a general desktop AI assistant for everyday work from your menu bar or system tray. These user guides cover setup, configuration, and optional capabilities.
+
+## Start here
+
+- [Walkthrough](walkthrough.md) - install Personal Agent, create a model profile, add an API key, and send your first message.
+- [Skills](skills.md) - understand skills, where to manage them, and how they affect assistant behavior.
+- [MCP tools](mcps.md) - connect Personal Agent to external tools and services with Model Context Protocol servers.
+
+## Related project information
+
+- [README](../README.md) - project overview, installation shortcuts, and development commands.
+- [GitHub Releases](https://github.com/acoliver/personal-agent/releases) - packaged downloads for macOS, Windows, and Linux.
+
+If you are new to Personal Agent, follow the walkthrough first, then return here when you want to add skills or MCP tools.

--- a/docs/mcps.md
+++ b/docs/mcps.md
@@ -67,18 +67,18 @@ If you delete an MCP from Settings, Personal Agent also removes the credentials 
 
 ### The MCP does not start
 
-- Confirm the command, package name, Docker image, or URL is correct.
-- Confirm required runtimes are installed, such as Node.js, npx, or Docker.
-- Confirm your network connection if the MCP uses a remote HTTP or SSE endpoint.
-- Check that required environment variables or API keys are present.
+- Verify the command, package name, Docker image, or URL.
+- Ensure required runtimes are installed, such as Node.js, npx, or Docker.
+- Check network connectivity if the MCP uses a remote HTTP or SSE endpoint.
+- Make sure required environment variables or API keys are present.
 - Toggle the MCP off and on, or restart Personal Agent.
 
 ### Authentication fails
 
 - Re-enter the credential in the MCP configuration screen.
-- Confirm the API key or token is active with the provider.
-- Confirm the credential has permission for the actions you are asking Personal Agent to perform.
-- Confirm the MCP expects the same environment variable name shown in Settings.
+- Verify the API key or token is active with the provider.
+- Ensure the credential has permission for the actions you are asking Personal Agent to perform.
+- Check that the MCP expects the same environment variable name shown in Settings.
 
 ### Tools do not appear in chat
 

--- a/docs/mcps.md
+++ b/docs/mcps.md
@@ -1,0 +1,96 @@
+# MCP tools
+
+MCP stands for Model Context Protocol. In Personal Agent, MCP servers provide tools that the assistant can use during a conversation, such as searching a service, reading from a data source, creating records, or calling a local utility.
+
+MCPs are optional. Personal Agent works as a general desktop AI assistant without them, but MCP tools can make it more useful when you want the assistant to interact with external systems.
+
+## Why configure MCP servers?
+
+You might configure an MCP server when you want Personal Agent to:
+
+- Search or query a service you use.
+- Work with a local or remote data source.
+- Trigger actions in another application.
+- Use specialized tools that are not built into the base chat experience.
+
+Each MCP server exposes its own set of tools. The exact capabilities depend on the server you add and the credentials you provide.
+
+## Where to manage MCPs
+
+Open **Settings**, then choose **MCP Tools**.
+
+From there you can:
+
+- See configured MCP servers and their status.
+- Toggle an MCP server on or off.
+- Add an MCP server.
+- Edit an existing MCP server.
+- Delete an MCP server and its stored credentials.
+
+The MCP add flow lets you search registries or enter a manual command, package, Docker image, or URL depending on the server you want to run.
+
+## Basic setup flow
+
+1. Open **Settings**.
+2. Choose **MCP Tools**.
+3. Click **+** to add a server.
+4. Search the registry or enter a manual MCP command or URL.
+5. Continue to the configuration screen.
+6. Review the server name, command or URL, and required environment variables.
+7. Add any required credentials or API keys.
+8. Save the configuration.
+9. Enable the MCP and confirm it reaches a running or healthy status.
+
+If the server requires a separate runtime such as Node.js, npx, Docker, or access to a remote URL, install or configure that dependency before enabling the MCP.
+
+## Safety expectations
+
+MCP tools can grant the assistant access to external systems. Treat an MCP server like any other application integration.
+
+Before enabling a server, check:
+
+- Who publishes or maintains it.
+- What tools it exposes.
+- What credentials or data it can access.
+- Whether it can modify data, not just read it.
+- Whether it runs local commands or connects to network services.
+
+Use **Tool Approval** settings to control how much confirmation Personal Agent requests before using MCP tools. If you are unsure, choose a more cautious approval mode and approve each tool use only after reading the request.
+
+## Credentials and secrets
+
+Personal Agent stores secret values in your operating system credential store when possible. Configuration files should reference secret labels or MCP-specific secure entries rather than storing raw API keys directly.
+
+If you delete an MCP from Settings, Personal Agent also removes the credentials associated with that MCP configuration.
+
+## Troubleshooting
+
+### The MCP does not start
+
+- Confirm the command, package name, Docker image, or URL is correct.
+- Confirm required runtimes are installed, such as Node.js, npx, or Docker.
+- Confirm your network connection if the MCP uses a remote HTTP or SSE endpoint.
+- Check that required environment variables or API keys are present.
+- Toggle the MCP off and on, or restart Personal Agent.
+
+### Authentication fails
+
+- Re-enter the credential in the MCP configuration screen.
+- Confirm the API key or token is active with the provider.
+- Confirm the credential has permission for the actions you are asking Personal Agent to perform.
+- Confirm the MCP expects the same environment variable name shown in Settings.
+
+### Tools do not appear in chat
+
+- Confirm the MCP is enabled.
+- Confirm the server status is running or healthy.
+- Ask the assistant whether MCP tools are available for the current task.
+- Reopen Settings and verify the MCP remains configured after saving.
+
+### The assistant asks for approval before using an MCP tool
+
+This is expected when your tool approval policy requires confirmation. Review the tool name, server name, and requested action before approving.
+
+### An MCP has too much access
+
+Disable or delete it from **Settings > MCP Tools**. You can also adjust the service-side credentials to reduce permissions, such as using a read-only token when a server only needs read access.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,84 @@
+# Skills
+
+Skills are optional task guides that Personal Agent can use during a conversation. A skill usually describes a specialized workflow, format, or tool-use pattern, such as working with a particular document type or following a repeatable research process.
+
+Skills do not replace the model profile you select for chat. They add focused instructions that help the assistant respond consistently when a task matches the skill.
+
+## Why use skills?
+
+Use skills when you want Personal Agent to follow a known approach for a recurring task. For example, a skill can help the assistant:
+
+- Follow a preferred report or briefing format.
+- Work with a specific file type.
+- Apply a checklist before producing an answer.
+- Remember a repeatable workflow without retyping the instructions in every chat.
+
+## Where to manage skills
+
+Open **Settings**, then choose the **Skills** section.
+
+From there you can:
+
+- Review discovered skills.
+- Enable or disable individual skills.
+- Refresh the skills list after adding or editing skill files.
+- Open the default skills folder.
+- Add extra watched directories that contain skills.
+
+Personal Agent discovers bundled skills, skills in the default user skills folder, and skills from any watched directories you add.
+
+## How skills affect assistant behavior
+
+When a skill is enabled, Personal Agent may tell the selected model that the skill is available. The assistant can then activate the skill when it seems relevant to your request.
+
+Important details:
+
+- Disabled skills are not offered to the assistant.
+- Enabling a skill does not force every response to use it.
+- A skill can influence the assistant's instructions, planning, and tool choices for matching tasks.
+- If tool approval is enabled, Personal Agent may ask before activating a skill or using tools suggested by that skill.
+
+You can always ask the assistant directly to use or avoid a specific skill in the current conversation.
+
+## Adding your own skills
+
+The simplest way to add personal skills is to place skill files in the default skills folder shown in Settings. You can also add a watched directory if you keep skills somewhere else.
+
+After adding or editing skills, click **Refresh Skills** in Settings so Personal Agent rescans the folders.
+
+## Safety notes
+
+Skills can change how the assistant approaches a task, so only enable skills you understand and trust.
+
+Before enabling a skill, consider:
+
+- What instructions it gives the assistant.
+- Whether it encourages use of files, network services, or MCP tools.
+- Whether it matches the kind of work you want Personal Agent to do.
+
+Use the **Tool Approval** settings if you want Personal Agent to ask before skill activation or related tool use.
+
+## Troubleshooting
+
+### A skill does not appear
+
+- Click **Refresh Skills** in Settings.
+- Confirm the skill file is in the default skills folder or a watched directory.
+- Confirm the watched directory still exists and can be read by your user account.
+- Restart Personal Agent if the list still does not update.
+
+### A skill appears but is not used
+
+- Confirm the skill is enabled.
+- Ask the assistant explicitly to use the skill for the task.
+- Check whether your request actually matches the skill's purpose.
+
+### A watched directory fails to add
+
+- Confirm the path is not empty.
+- Confirm your user account can create or read the directory.
+- Use an absolute path if a relative path does not resolve as expected.
+
+### Skill activation asks for approval
+
+This is expected when tool approval settings require confirmation. Approve the activation only if you trust the skill and it is relevant to the task.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,6 +1,6 @@
 # Personal Agent walkthrough
 
-This walkthrough takes you from installation to your first chat. The example profile uses Z.ai's coding plan with GLM-5.1 because it is a current, sensible OpenAI-compatible model setup.
+This walkthrough takes you from installation to your first chat. Personal Agent is a general desktop AI assistant: use it to draft reports, summarize research, prepare plans, review notes, or work with connected tools from a compact menu-bar or system-tray chat panel.
 
 ## 1. Install Personal Agent
 
@@ -37,26 +37,26 @@ The screenshot above was captured from the real running app.
 
 ## 3. Open settings
 
-Click the gear icon in the chat panel toolbar. Settings contain the profile list, model configuration, API key management, appearance, MCP tools, and security options.
+Click the gear icon in the chat panel toolbar. Settings contain the profile list, model configuration, API key management, appearance, MCP tools, skills, tool approval, and security options.
 
 ## 4. Create a model profile
 
-1. In settings, open the **Models** section.
+1. In settings, open the **Models** or **Profiles** section.
 2. Click **+** to add a profile.
-3. Give it a clear name, for example `Z.ai GLM-5.1 Coding`.
+3. Give it a clear name, for example `Z.ai GLM-5.1 General`.
 4. Choose the provider/model from the registry if available. If you configure it manually, use the values below.
 
-Example Z.ai coding-plan profile:
+Example Z.ai general assistant profile:
 
 | Field | Value |
 | --- | --- |
-| Profile name | `Z.ai GLM-5.1 Coding` |
+| Profile name | `Z.ai GLM-5.1 General` |
 | Provider | `z-ai` or a custom OpenAI-compatible provider entry for Z.ai |
 | Model | `glm-5.1` |
 | Base URL | `https://api.z.ai/api/paas/v4` |
 | API key label | `z-ai` |
-| Temperature | `0.7` |
-| Max tokens | `4096` |
+| Output tokens | `40000` |
+| Context limit | `200000` |
 
 If the UI presents a model picker, prefer selecting the Z.ai GLM-5.1 model from the registry instead of typing provider details by hand. Manual fields are useful when the registry has not yet been refreshed.
 
@@ -77,19 +77,28 @@ Profile files reference the key label; they should not contain the API key itsel
 
 ## 6. Select the profile
 
-Return to the chat panel and select `Z.ai GLM-5.1 Coding` from the profile dropdown. If it does not appear, reopen settings and verify that the profile was saved.
+Return to the chat panel and select `Z.ai GLM-5.1 General` from the profile dropdown. If it does not appear, reopen settings and verify that the profile was saved.
 
 ## 7. Send your first message
 
 Click the input field, type a message, and press Enter or click **Send**.
 
-Try a small coding prompt first, for example:
+Try a general-purpose assistant prompt first, for example:
 
 ```text
-Write a Rust function that returns true when a string is a palindrome. Include a short explanation.
+Write a one-page briefing on the benefits and risks of adopting AI assistants for a small consulting firm. Include an executive summary and practical next steps.
 ```
 
 Responses stream into the chat panel as the model generates them. Conversation history is saved automatically.
+
+## 8. Optional: connect skills and MCP tools
+
+Personal Agent can do more when you enable additional capabilities:
+
+- [Skills](skills.md) provide task-specific instructions or workflows that the assistant can activate when relevant.
+- [MCP tools](mcps.md) connect the assistant to external services, local tools, or data sources through Model Context Protocol servers.
+
+Only enable skills or MCP servers you understand and trust. Tool approval settings let you decide when Personal Agent should ask before using a tool.
 
 ## Troubleshooting
 
@@ -101,7 +110,7 @@ Responses stream into the chat panel as the model generates them. Conversation h
 
 ### The profile dropdown is empty
 
-Open settings, go to **Models**, and create a profile. Save it, then return to chat. If needed, restart the app.
+Open settings, go to **Models** or **Profiles**, and create a profile. Save it, then return to chat. If needed, restart the app.
 
 ### The model call fails with an authentication error
 
@@ -115,6 +124,10 @@ Reopen the profile and confirm:
 ### The model is missing from the picker
 
 Use **Refresh Models** in settings. If it still does not appear, configure the profile manually with the Z.ai GLM-5.1 values above.
+
+### Responses stop early
+
+Reopen the profile and confirm the output-token setting is large enough for the task. For GLM-5.1, the example above uses approximately 40000 output tokens for long-form general assistant work.
 
 ### Linux packages install but no window opens
 


### PR DESCRIPTION
## Summary

- Reframes the walkthrough around Personal Agent as a general desktop AI assistant instead of a coding tool.
- Updates the Z.ai GLM-5.1 walkthrough profile example to omit temperature and recommend 40000 output tokens with a 200000 context limit.
- Adds a docs index plus user-facing skills and MCP tools documentation.
- Points the top-level README to the docs index.

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --tests
- cargo xtask guard
- python -m lizard -C 50 -L 100 -w src/
- source .venv-lizard/bin/activate; find src -name "*.rs" file-length gate matching CI
- cargo coverage

Fixes #198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a new documentation hub for streamlined navigation across all guides
* Introduced step-by-step MCP tools guide covering setup, security, and troubleshooting
* Created skills management guide for enabling custom and bundled skills
* Updated walkthrough with improved setup instructions and configuration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->