### PR TITLE
Route new-chat sends to fresh conversations (Fixes #203)

### DIFF
--- a/src/config/provider_defaults.rs
+++ b/src/config/provider_defaults.rs
@@ -49,3 +49,24 @@ pub fn provider_api_url_map(
         .filter_map(|provider_id| provider_api_url(&provider_id).map(|url| (provider_id, url)))
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_provider_defaults_include_zai_coding_endpoint() {
+        assert_eq!(
+            builtin_provider_api_url("zai-coding-plan").as_deref(),
+            Some("https://api.z.ai/api/coding/paas/v4")
+        );
+    }
+
+    #[test]
+    fn bundled_provider_defaults_include_zai_general_endpoint() {
+        assert_eq!(
+            builtin_provider_api_url("zai").as_deref(),
+            Some("https://api.z.ai/api/paas/v4")
+        );
+    }
+}

--- a/src/config/provider_quirks.toml
+++ b/src/config/provider_quirks.toml
@@ -24,6 +24,22 @@ base_url = "https://api.anthropic.com/v1"
 [openai]
 base_url = "https://api.openai.com/v1"
 
+[zai]
+transport = "openai"
+base_url = "https://api.z.ai/api/paas/v4"
+
+[zai-coding-plan]
+transport = "openai"
+base_url = "https://api.z.ai/api/coding/paas/v4"
+
+[zhipuai]
+transport = "openai"
+base_url = "https://open.bigmodel.cn/api/paas/v4"
+
+[zhipuai-coding-plan]
+transport = "openai"
+base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+
 [kimi-for-coding]
 transport = "openai"
 base_url = "https://api.kimi.com/coding/v1"

--- a/src/config/quirks_manifest.rs
+++ b/src/config/quirks_manifest.rs
@@ -155,6 +155,28 @@ mod tests {
     }
 
     #[test]
+    fn zai_entries_have_openai_transport_and_distinct_plan_endpoints() {
+        let entries: HashMap<String, QuirksEntry> =
+            toml::from_str(BUNDLED_MANIFEST).expect("parse");
+
+        let general = entries.get("zai").expect("zai entry should exist");
+        assert_eq!(general.transport.as_deref(), Some("openai"));
+        assert_eq!(
+            general.base_url.as_deref(),
+            Some("https://api.z.ai/api/paas/v4")
+        );
+
+        let coding = entries
+            .get("zai-coding-plan")
+            .expect("zai coding plan entry should exist");
+        assert_eq!(coding.transport.as_deref(), Some("openai"));
+        assert_eq!(
+            coding.base_url.as_deref(),
+            Some("https://api.z.ai/api/coding/paas/v4")
+        );
+    }
+
+    #[test]
     fn user_overlay_overrides_bundled_entries() {
         let bundled: HashMap<String, QuirksEntry> =
             toml::from_str(BUNDLED_MANIFEST).expect("parse bundled");
@@ -229,6 +251,10 @@ base_url = "https://my-custom.example.com/v1"
         let expected = [
             "anthropic",
             "openai",
+            "zai",
+            "zai-coding-plan",
+            "zhipuai",
+            "zhipuai-coding-plan",
             "kimi-for-coding",
             "openrouter",
             "synthetic",

--- a/src/events/bus.rs
+++ b/src/events/bus.rs
@@ -176,6 +176,7 @@ mod tests {
         let bus = EventBus::new(16);
         let mut rx = bus.subscribe();
         let event = AppEvent::User(UserEvent::SendMessage {
+            conversation_id: None,
             text: "Hello".to_string(),
         });
 
@@ -273,18 +274,23 @@ mod tests {
 
         let events = vec![
             AppEvent::User(UserEvent::SendMessage {
+                conversation_id: None,
                 text: "First".to_string(),
             }),
             AppEvent::User(UserEvent::SendMessage {
+                conversation_id: None,
                 text: "Second".to_string(),
             }),
             AppEvent::User(UserEvent::SendMessage {
+                conversation_id: None,
                 text: "Third".to_string(),
             }),
             AppEvent::User(UserEvent::SendMessage {
+                conversation_id: None,
                 text: "Fourth".to_string(),
             }),
             AppEvent::User(UserEvent::SendMessage {
+                conversation_id: None,
                 text: "Fifth".to_string(),
             }),
         ];
@@ -434,6 +440,7 @@ mod tests {
 
         // When - simulate send message flow
         let _ = bus.publish(AppEvent::User(UserEvent::SendMessage {
+            conversation_id: None,
             text: "Hello".to_string(),
         }));
         let _ = bus.publish(AppEvent::Chat(ChatEvent::StreamStarted {

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -45,8 +45,16 @@ pub enum AppEvent {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum UserEvent {
     // ===== Chat Actions =====
-    /// User clicked send or pressed Enter
-    SendMessage { text: String },
+    /// User clicked send or pressed Enter.
+    ///
+    /// The optional `conversation_id` is the UI-selected target at send time.
+    /// A `None` target means the composer is intentionally in a new-chat draft
+    /// state, so the presenter must not reuse a stale service-active
+    /// conversation.
+    SendMessage {
+        text: String,
+        conversation_id: Option<Uuid>,
+    },
 
     /// User requested to stop a conversation's active stream.
     ///

--- a/src/presentation/chat_presenter.rs
+++ b/src/presentation/chat_presenter.rs
@@ -144,13 +144,17 @@ impl ChatPresenter {
         event: UserEvent,
     ) {
         match event {
-            UserEvent::SendMessage { text } => {
+            UserEvent::SendMessage {
+                text,
+                conversation_id,
+            } => {
                 Self::handle_send_message(
                     conversation_service,
                     chat_service,
                     profile_service,
                     view_tx,
                     text,
+                    conversation_id,
                 )
                 .await;
             }
@@ -485,6 +489,7 @@ impl ChatPresenter {
         profile_service: &Arc<dyn ProfileService>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
         content: String,
+        requested_conversation_id: Option<Uuid>,
     ) {
         // Validate non-empty
         let trimmed = content.trim();
@@ -493,24 +498,28 @@ impl ChatPresenter {
         }
 
         // Get or create conversation
-        let conversation_id =
-            match Self::get_or_create_conversation(conversation_service, profile_service, view_tx)
-                .await
-            {
-                Ok(id) => id,
-                Err(e) => {
-                    tracing::error!("Failed to get/create conversation: {}", e);
-                    let error_msg = format!("Failed to create conversation: {e}");
-                    let _ = view_tx
-                        .send(ViewCommand::ShowError {
-                            title: "Conversation Error".to_string(),
-                            message: error_msg.clone(),
-                            severity: ErrorSeverity::Error,
-                        })
-                        .await;
-                    return;
-                }
-            };
+        let conversation_id = match Self::get_or_create_conversation(
+            conversation_service,
+            profile_service,
+            view_tx,
+            requested_conversation_id,
+        )
+        .await
+        {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::error!("Failed to get/create conversation: {}", e);
+                let error_msg = format!("Failed to create conversation: {e}");
+                let _ = view_tx
+                    .send(ViewCommand::ShowError {
+                        title: "Conversation Error".to_string(),
+                        message: error_msg.clone(),
+                        severity: ErrorSeverity::Error,
+                    })
+                    .await;
+                return;
+            }
+        };
 
         // Emit view commands for user message
         let _ = view_tx
@@ -828,11 +837,26 @@ impl ChatPresenter {
         conversation_service: &Arc<dyn ConversationService>,
         profile_service: &Arc<dyn ProfileService>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
+        requested_conversation_id: Option<Uuid>,
     ) -> Result<Uuid, Box<dyn std::error::Error + Send + Sync>> {
-        // Try to get active conversation
-        let active_result = conversation_service.get_active().await;
-        if let Ok(Some(id)) = active_result {
+        if let Some(id) = requested_conversation_id {
+            conversation_service
+                .set_active(id)
+                .await
+                .map_err(Box::<dyn std::error::Error + Send + Sync>::from)?;
             return Ok(id);
+        }
+
+        if let Ok(Some(id)) = conversation_service.get_active().await {
+            if let Ok(metadata) = conversation_service.list_metadata(None, None).await {
+                let active_is_empty = metadata
+                    .iter()
+                    .find(|conversation| conversation.id == id)
+                    .is_some_and(|conversation| conversation.message_count == 0);
+                if active_is_empty {
+                    return Ok(id);
+                }
+            }
         }
 
         let default_profile = Self::resolve_default_profile_id(profile_service)

--- a/src/presentation/chat_presenter.rs
+++ b/src/presentation/chat_presenter.rs
@@ -10,14 +10,27 @@ use super::view_command::{
 };
 use super::{Presenter, PresenterError, ViewCommand};
 use crate::events::bus::EventBus;
-use crate::events::{
-    types::{ConversationEvent, UserEvent},
-    AppEvent,
-};
+use crate::events::{types::ConversationEvent, AppEvent};
+
 use crate::models::ConversationExportFormat;
 use crate::services::{
     AppSettingsService, ChatService, ConversationService, ProfileService, ServiceError,
 };
+
+type PendingDraftConversation = Arc<std::sync::Mutex<Option<Uuid>>>;
+
+#[allow(clippy::struct_field_names)]
+pub(super) struct ChatPresenterDeps<'a> {
+    pub(super) conversation_service: &'a Arc<dyn ConversationService>,
+    pub(super) chat_service: &'a Arc<dyn ChatService>,
+    pub(super) profile_service: &'a Arc<dyn ProfileService>,
+}
+
+pub(super) struct ChatPresenterState<'a> {
+    pub(super) app_settings_service: &'a Arc<dyn AppSettingsService>,
+    pub(super) current_export_format: &'a Arc<std::sync::Mutex<ConversationExportFormat>>,
+    pub(super) pending_draft_conversation_id: &'a PendingDraftConversation,
+}
 
 pub struct ChatPresenter {
     event_bus: Arc<EventBus>,
@@ -27,6 +40,8 @@ pub struct ChatPresenter {
     app_settings_service: Arc<dyn AppSettingsService>,
     view_tx: mpsc::Sender<ViewCommand>,
     running: Arc<std::sync::atomic::AtomicBool>,
+    pending_draft_conversation_id: PendingDraftConversation,
+
     current_export_format: Arc<std::sync::Mutex<crate::models::ConversationExportFormat>>,
 }
 
@@ -50,9 +65,9 @@ impl ChatPresenter {
             current_export_format: Arc::new(std::sync::Mutex::new(
                 ConversationExportFormat::default(),
             )),
+            pending_draft_conversation_id: Arc::new(std::sync::Mutex::new(None)),
         }
     }
-
     /// Start the presenter event loop.
     ///
     /// # Errors
@@ -94,30 +109,18 @@ impl ChatPresenter {
         self.running.load(std::sync::atomic::Ordering::Relaxed)
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn handle_event(
-        conversation_service: &Arc<dyn ConversationService>,
-        chat_service: &Arc<dyn ChatService>,
-        profile_service: &Arc<dyn ProfileService>,
-        app_settings_service: &Arc<dyn AppSettingsService>,
-        current_export_format: &Arc<std::sync::Mutex<ConversationExportFormat>>,
+        deps: &ChatPresenterDeps<'_>,
+        state: &ChatPresenterState<'_>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
         event: AppEvent,
     ) {
         tracing::debug!("ChatPresenter::handle_event: {:?}", event);
         match event {
             AppEvent::User(user_evt) => {
-                Self::handle_user_event(
-                    conversation_service,
-                    chat_service,
-                    profile_service,
-                    app_settings_service,
-                    current_export_format,
-                    view_tx,
-                    user_evt,
-                )
-                .await;
+                Self::handle_user_event(deps, state, view_tx, user_evt).await;
             }
+
             AppEvent::Chat(chat_evt) => {
                 tracing::info!("ChatPresenter handling ChatEvent: {:?}", chat_evt);
                 Self::handle_chat_event(view_tx, chat_evt).await;
@@ -129,111 +132,7 @@ impl ChatPresenter {
         }
     }
 
-    /// Handle user events
-    ///
-    /// @plan PLAN-20250125-REFACTOR.P12
-    /// @requirement REQ-027.1
-    #[allow(clippy::too_many_arguments)]
-    async fn handle_user_event(
-        conversation_service: &Arc<dyn ConversationService>,
-        chat_service: &Arc<dyn ChatService>,
-        profile_service: &Arc<dyn ProfileService>,
-        app_settings_service: &Arc<dyn AppSettingsService>,
-        current_export_format: &Arc<std::sync::Mutex<ConversationExportFormat>>,
-        view_tx: &mut mpsc::Sender<ViewCommand>,
-        event: UserEvent,
-    ) {
-        match event {
-            UserEvent::SendMessage {
-                text,
-                conversation_id,
-            } => {
-                Self::handle_send_message(
-                    conversation_service,
-                    chat_service,
-                    profile_service,
-                    view_tx,
-                    text,
-                    conversation_id,
-                )
-                .await;
-            }
-            // @plan PLAN-20260416-ISSUE173.P05
-            UserEvent::StopStreaming { conversation_id } => {
-                Self::handle_stop_streaming(chat_service, view_tx, conversation_id).await;
-            }
-            UserEvent::NewConversation => {
-                Self::handle_new_conversation(conversation_service, profile_service, view_tx).await;
-            }
-            UserEvent::ToggleThinking => {
-                Self::handle_toggle_thinking(view_tx).await;
-            }
-            UserEvent::ToggleEmojiFilter => {
-                Self::handle_toggle_emoji_filter(app_settings_service, view_tx).await;
-            }
-            UserEvent::ConfirmRenameConversation { id, title } => {
-                Self::handle_rename_conversation(conversation_service, view_tx, id, title).await;
-            }
-            UserEvent::SelectConversation {
-                id,
-                selection_generation,
-            } => {
-                Self::handle_select_conversation(
-                    conversation_service,
-                    view_tx,
-                    id,
-                    selection_generation,
-                )
-                .await;
-            }
-            UserEvent::RefreshHistory | UserEvent::RefreshConversations => {
-                let _ = Self::emit_conversation_list(conversation_service, view_tx).await;
-            }
-            UserEvent::SelectConversationExportFormat { format } => {
-                Self::handle_select_conversation_export_format(
-                    app_settings_service,
-                    current_export_format,
-                    view_tx,
-                    format,
-                )
-                .await;
-            }
-            UserEvent::SaveConversation => {
-                Self::handle_save_conversation(
-                    conversation_service,
-                    app_settings_service,
-                    current_export_format,
-                    view_tx,
-                )
-                .await;
-            }
-            UserEvent::SaveErrorLog { format } => {
-                Self::handle_save_error_log(app_settings_service, view_tx, format).await;
-            }
-            UserEvent::SelectChatProfile { id } => {
-                Self::handle_select_chat_profile(conversation_service, id).await;
-            }
-            UserEvent::SetExportDirectory { path } => {
-                Self::handle_set_export_directory(app_settings_service, view_tx, path).await;
-            }
-            UserEvent::ToolApprovalResponse {
-                request_id,
-                decision,
-            } => {
-                Self::handle_tool_approval_response(chat_service, view_tx, request_id, decision)
-                    .await;
-            }
-            UserEvent::ToggleWindowMode => {
-                let _ = view_tx.send(ViewCommand::ToggleWindowMode).await;
-            }
-            UserEvent::SearchConversations { query } => {
-                Self::handle_search_conversations(conversation_service, view_tx, query).await;
-            }
-            _ => {} // Ignore other user events
-        }
-    }
-
-    async fn handle_tool_approval_response(
+    pub(super) async fn handle_tool_approval_response(
         chat_service: &Arc<dyn ChatService>,
         view_tx: &mpsc::Sender<ViewCommand>,
         request_id: String,
@@ -253,7 +152,7 @@ impl ChatPresenter {
         }
     }
 
-    async fn handle_search_conversations(
+    pub(super) async fn handle_search_conversations(
         conversation_service: &Arc<dyn ConversationService>,
         view_tx: &mpsc::Sender<ViewCommand>,
         query: String,
@@ -383,22 +282,25 @@ impl ChatPresenter {
         let profile_service = self.profile_service.clone();
         let app_settings_service = self.app_settings_service.clone();
         let current_export_format = self.current_export_format.clone();
+        let pending_draft_conversation_id = self.pending_draft_conversation_id.clone();
+
         let mut view_tx = self.view_tx.clone();
 
         tokio::spawn(async move {
             while running.load(std::sync::atomic::Ordering::Relaxed) {
                 match rx.recv().await {
                     Ok(event) => {
-                        Self::handle_event(
-                            &conversation_service,
-                            &chat_service,
-                            &profile_service,
-                            &app_settings_service,
-                            &current_export_format,
-                            &mut view_tx,
-                            event,
-                        )
-                        .await;
+                        let deps = ChatPresenterDeps {
+                            conversation_service: &conversation_service,
+                            chat_service: &chat_service,
+                            profile_service: &profile_service,
+                        };
+                        let state = ChatPresenterState {
+                            app_settings_service: &app_settings_service,
+                            current_export_format: &current_export_format,
+                            pending_draft_conversation_id: &pending_draft_conversation_id,
+                        };
+                        Self::handle_event(&deps, &state, &mut view_tx, event).await;
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         tracing::warn!("ChatPresenter lagged: {} events missed", n);
@@ -413,7 +315,7 @@ impl ChatPresenter {
         });
     }
 
-    async fn emit_conversation_list(
+    pub(super) async fn emit_conversation_list(
         conversation_service: &Arc<dyn ConversationService>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
     ) -> Result<(), ServiceError> {
@@ -483,13 +385,15 @@ impl ChatPresenter {
     ///
     /// @plan PLAN-20250125-REFACTOR.P12
     /// @requirement REQ-027.1
-    async fn handle_send_message(
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn handle_send_message(
         conversation_service: &Arc<dyn ConversationService>,
         chat_service: &Arc<dyn ChatService>,
         profile_service: &Arc<dyn ProfileService>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
         content: String,
         requested_conversation_id: Option<Uuid>,
+        pending_draft_conversation_id: &PendingDraftConversation,
     ) {
         // Validate non-empty
         let trimmed = content.trim();
@@ -503,6 +407,7 @@ impl ChatPresenter {
             profile_service,
             view_tx,
             requested_conversation_id,
+            pending_draft_conversation_id,
         )
         .await
         {
@@ -568,7 +473,7 @@ impl ChatPresenter {
     ///
     /// @plan PLAN-20250128-PRESENTERS.P01
     /// @requirement REQ-027.1
-    async fn handle_toggle_thinking(view_tx: &mut mpsc::Sender<ViewCommand>) {
+    pub(super) async fn handle_toggle_thinking(view_tx: &mut mpsc::Sender<ViewCommand>) {
         let _ = view_tx.send(ViewCommand::ToggleThinkingVisibility).await;
     }
 
@@ -576,7 +481,7 @@ impl ChatPresenter {
     ///
     /// @plan PLAN-20250128-PRESENTERS.P01
     /// @requirement REQ-027.1
-    async fn handle_rename_conversation(
+    pub(super) async fn handle_rename_conversation(
         conversation_service: &Arc<dyn ConversationService>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
         id: Uuid,
@@ -654,7 +559,7 @@ impl ChatPresenter {
     ///
     /// @plan PLAN-20260416-ISSUE173.P05
     /// @requirement REQ-173-002.3
-    async fn handle_stop_streaming(
+    pub(super) async fn handle_stop_streaming(
         chat_service: &Arc<dyn ChatService>,
         _view_tx: &mut mpsc::Sender<ViewCommand>,
         conversation_id: Uuid,
@@ -668,7 +573,7 @@ impl ChatPresenter {
     /// When the user picks a different profile in the chat title-bar dropdown,
     /// update the active conversation's `profile_id` so the next send uses
     /// that profile (and its provider-specific headers/base-URL).
-    async fn handle_select_chat_profile(
+    pub(super) async fn handle_select_chat_profile(
         conversation_service: &Arc<dyn ConversationService>,
         profile_id: Uuid,
     ) {
@@ -690,10 +595,11 @@ impl ChatPresenter {
     ///
     /// @plan PLAN-20250125-REFACTOR.P12
     /// @requirement REQ-027.1
-    async fn handle_new_conversation(
+    pub(super) async fn handle_new_conversation(
         conversation_service: &Arc<dyn ConversationService>,
         profile_service: &Arc<dyn ProfileService>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
+        pending_draft_conversation_id: &PendingDraftConversation,
     ) {
         let default_profile = match Self::resolve_default_profile_id(profile_service).await {
             Ok(id) => id,
@@ -717,6 +623,11 @@ impl ChatPresenter {
             Ok(conversation) => {
                 let conversation_id = conversation.id;
                 let _ = conversation_service.set_active(conversation_id).await;
+                Self::set_pending_draft_conversation_id(
+                    pending_draft_conversation_id,
+                    Some(conversation_id),
+                );
+
                 let _ = view_tx
                     .send(ViewCommand::ConversationCreated {
                         id: conversation_id,
@@ -750,7 +661,7 @@ impl ChatPresenter {
     ///
     /// @plan PLAN-20250125-REFACTOR.P12
     /// @requirement REQ-027.1
-    async fn handle_select_conversation(
+    pub(super) async fn handle_select_conversation(
         conversation_service: &Arc<dyn ConversationService>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
         id: Uuid,
@@ -829,31 +740,65 @@ impl ChatPresenter {
         }
     }
 
+    pub(super) fn pending_draft_conversation_id(
+        pending_draft_conversation_id: &PendingDraftConversation,
+    ) -> Option<Uuid> {
+        match pending_draft_conversation_id.lock() {
+            Ok(guard) => *guard,
+            Err(e) => {
+                tracing::warn!("Failed to read pending draft conversation id: {e}");
+                None
+            }
+        }
+    }
+
+    pub(super) fn set_pending_draft_conversation_id(
+        pending_draft_conversation_id: &PendingDraftConversation,
+        conversation_id: Option<Uuid>,
+    ) {
+        match pending_draft_conversation_id.lock() {
+            Ok(mut guard) => *guard = conversation_id,
+            Err(e) => tracing::warn!("Failed to update pending draft conversation id: {e}"),
+        }
+    }
+
     /// Get or create active conversation
     ///
     /// @plan PLAN-20250125-REFACTOR.P12
     /// @requirement REQ-027.1
-    async fn get_or_create_conversation(
+    pub(super) async fn get_or_create_conversation(
         conversation_service: &Arc<dyn ConversationService>,
         profile_service: &Arc<dyn ProfileService>,
         view_tx: &mut mpsc::Sender<ViewCommand>,
         requested_conversation_id: Option<Uuid>,
+        pending_draft_conversation_id: &PendingDraftConversation,
     ) -> Result<Uuid, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(id) = requested_conversation_id {
             conversation_service
                 .set_active(id)
                 .await
                 .map_err(Box::<dyn std::error::Error + Send + Sync>::from)?;
+            Self::set_pending_draft_conversation_id(pending_draft_conversation_id, None);
+
             return Ok(id);
         }
 
         if let Ok(Some(id)) = conversation_service.get_active().await {
-            if let Ok(metadata) = conversation_service.list_metadata(None, None).await {
+            let pending_draft_id =
+                Self::pending_draft_conversation_id(pending_draft_conversation_id);
+            if pending_draft_id == Some(id) {
+                let Ok(metadata) = conversation_service.list_metadata(None, None).await else {
+                    return Err(Box::new(ServiceError::Internal(
+                        "Failed to list conversations for pending draft validation".to_string(),
+                    )));
+                };
+
                 let active_is_empty = metadata
                     .iter()
                     .find(|conversation| conversation.id == id)
                     .is_some_and(|conversation| conversation.message_count == 0);
                 if active_is_empty {
+                    Self::set_pending_draft_conversation_id(pending_draft_conversation_id, None);
                     return Ok(id);
                 }
             }
@@ -872,6 +817,8 @@ impl ChatPresenter {
                 let conversation_id = conversation.id;
 
                 let _ = conversation_service.set_active(conversation_id).await;
+                Self::set_pending_draft_conversation_id(pending_draft_conversation_id, None);
+
                 let _ = view_tx
                     .send(ViewCommand::ConversationCreated {
                         id: conversation_id,
@@ -892,7 +839,7 @@ impl ChatPresenter {
         }
     }
 
-    async fn resolve_default_profile_id(
+    pub(super) async fn resolve_default_profile_id(
         profile_service: &Arc<dyn ProfileService>,
     ) -> Result<Uuid, String> {
         if let Some(default_profile) = profile_service

--- a/src/presentation/chat_presenter_cancel_tests.rs
+++ b/src/presentation/chat_presenter_cancel_tests.rs
@@ -75,6 +75,14 @@ async fn handle_stop_streaming_forwards_conversation_id() {
     let conversation_service = Arc::new(MockConversationService) as Arc<dyn ConversationService>;
     let (view_tx, _view_rx) = mpsc::channel::<ViewCommand>(100);
 
+    let profile_service = Arc::new(MockProfileService) as Arc<dyn ProfileService>;
+    let app_settings_service = Arc::new(MockAppSettingsService) as Arc<dyn AppSettingsService>;
+    let current_export_format = Arc::new(std::sync::Mutex::new(
+        crate::models::ConversationExportFormat::Md,
+    ));
+
+    let pending_draft_conversation_id = Arc::new(std::sync::Mutex::new(None));
+
     let conversation_id_a = Uuid::new_v4();
 
     // Dispatch StopStreaming with conversation_id A using struct-variant syntax.
@@ -83,19 +91,17 @@ async fn handle_stop_streaming_forwards_conversation_id() {
         conversation_id: conversation_id_a,
     };
 
-    // Process the event through the presenter
-    ChatPresenter::handle_user_event(
-        &conversation_service,
-        &(chat_service.clone() as Arc<dyn ChatService>),
-        &(Arc::new(MockProfileService) as Arc<dyn ProfileService>),
-        &(Arc::new(MockAppSettingsService) as Arc<dyn AppSettingsService>),
-        &Arc::new(std::sync::Mutex::new(
-            crate::models::ConversationExportFormat::Md,
-        )),
-        &mut view_tx.clone(),
-        event,
-    )
-    .await;
+    let deps = ChatPresenterDeps {
+        conversation_service: &conversation_service,
+        chat_service: &(chat_service.clone() as Arc<dyn ChatService>),
+        profile_service: &profile_service,
+    };
+    let state = ChatPresenterState {
+        app_settings_service: &app_settings_service,
+        current_export_format: &current_export_format,
+        pending_draft_conversation_id: &pending_draft_conversation_id,
+    };
+    ChatPresenter::handle_user_event(&deps, &state, &mut view_tx.clone(), event).await;
 
     // Assert the mock received exactly one cancel(A) call
     let cancelled = chat_service.cancelled_ids();
@@ -114,7 +120,15 @@ async fn handle_stop_streaming_forwards_conversation_id() {
 async fn handle_stop_streaming_does_not_cancel_other_conversations() {
     let chat_service = Arc::new(RecordingChatService::new());
     let conversation_service = Arc::new(MockConversationService) as Arc<dyn ConversationService>;
+    let profile_service = Arc::new(MockProfileService) as Arc<dyn ProfileService>;
+    let app_settings_service = Arc::new(MockAppSettingsService) as Arc<dyn AppSettingsService>;
+    let current_export_format = Arc::new(std::sync::Mutex::new(
+        crate::models::ConversationExportFormat::Md,
+    ));
+
     let (view_tx, _view_rx) = mpsc::channel::<ViewCommand>(100);
+
+    let pending_draft_conversation_id = Arc::new(std::sync::Mutex::new(None));
 
     let conversation_id_a = Uuid::new_v4();
     let conversation_id_b = Uuid::new_v4();
@@ -125,19 +139,17 @@ async fn handle_stop_streaming_does_not_cancel_other_conversations() {
         conversation_id: conversation_id_a,
     };
 
-    // Process the event through the presenter
-    ChatPresenter::handle_user_event(
-        &conversation_service,
-        &(chat_service.clone() as Arc<dyn ChatService>),
-        &(Arc::new(MockProfileService) as Arc<dyn ProfileService>),
-        &(Arc::new(MockAppSettingsService) as Arc<dyn AppSettingsService>),
-        &Arc::new(std::sync::Mutex::new(
-            crate::models::ConversationExportFormat::Md,
-        )),
-        &mut view_tx.clone(),
-        event,
-    )
-    .await;
+    let deps = ChatPresenterDeps {
+        conversation_service: &conversation_service,
+        chat_service: &(chat_service.clone() as Arc<dyn ChatService>),
+        profile_service: &profile_service,
+    };
+    let state = ChatPresenterState {
+        app_settings_service: &app_settings_service,
+        current_export_format: &current_export_format,
+        pending_draft_conversation_id: &pending_draft_conversation_id,
+    };
+    ChatPresenter::handle_user_event(&deps, &state, &mut view_tx.clone(), event).await;
 
     // Assert cancel(B) was NEVER called
     let cancelled = chat_service.cancelled_ids();

--- a/src/presentation/chat_presenter_event.rs
+++ b/src/presentation/chat_presenter_event.rs
@@ -1,0 +1,179 @@
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use super::chat_presenter::{ChatPresenter, ChatPresenterDeps, ChatPresenterState};
+use super::ViewCommand;
+use crate::events::types::{ToolApprovalResponseAction, UserEvent};
+use crate::models::ConversationExportFormat;
+
+impl ChatPresenter {
+    /// Handle user events
+    ///
+    /// @plan PLAN-20250125-REFACTOR.P12
+    /// @requirement REQ-027.1
+    #[allow(clippy::too_many_lines)]
+    pub(super) async fn handle_user_event(
+        deps: &ChatPresenterDeps<'_>,
+        state: &ChatPresenterState<'_>,
+        view_tx: &mut mpsc::Sender<ViewCommand>,
+        event: UserEvent,
+    ) {
+        match event {
+            UserEvent::SendMessage {
+                text,
+                conversation_id,
+            } => {
+                Self::handle_send_message_for_event(deps, state, view_tx, text, conversation_id)
+                    .await;
+            }
+            UserEvent::StopStreaming { conversation_id } => {
+                Self::handle_stop_streaming(deps.chat_service, view_tx, conversation_id).await;
+            }
+            UserEvent::NewConversation => {
+                Self::handle_new_conversation_for_event(deps, state, view_tx).await;
+            }
+            UserEvent::ToggleThinking => {
+                Self::handle_toggle_thinking(view_tx).await;
+            }
+            UserEvent::ToggleEmojiFilter => {
+                Self::handle_toggle_emoji_filter(state.app_settings_service, view_tx).await;
+            }
+            UserEvent::ConfirmRenameConversation { id, title } => {
+                Self::handle_rename_conversation_for_event(deps, view_tx, id, title).await;
+            }
+            UserEvent::SelectConversation {
+                id,
+                selection_generation,
+            } => {
+                Self::handle_select_conversation_for_event(deps, view_tx, id, selection_generation)
+                    .await;
+            }
+            UserEvent::RefreshHistory | UserEvent::RefreshConversations => {
+                let _ = Self::emit_conversation_list(deps.conversation_service, view_tx).await;
+            }
+            UserEvent::SelectConversationExportFormat { format } => {
+                Self::handle_select_export_format_for_event(state, view_tx, format).await;
+            }
+            UserEvent::SaveConversation => {
+                Self::handle_save_conversation_for_event(deps, state, view_tx).await;
+            }
+            UserEvent::SaveErrorLog { format } => {
+                Self::handle_save_error_log(state.app_settings_service, view_tx, format).await;
+            }
+            UserEvent::SelectChatProfile { id } => {
+                Self::handle_select_chat_profile(deps.conversation_service, id).await;
+            }
+            UserEvent::SetExportDirectory { path } => {
+                Self::handle_set_export_directory(state.app_settings_service, view_tx, path).await;
+            }
+            UserEvent::ToolApprovalResponse {
+                request_id,
+                decision,
+            } => {
+                Self::handle_tool_approval_response_for_event(deps, view_tx, request_id, decision)
+                    .await;
+            }
+            UserEvent::ToggleWindowMode => {
+                let _ = view_tx.send(ViewCommand::ToggleWindowMode).await;
+            }
+            UserEvent::SearchConversations { query } => {
+                Self::handle_search_conversations(deps.conversation_service, view_tx, query).await;
+            }
+            _ => {}
+        }
+    }
+
+    async fn handle_send_message_for_event(
+        deps: &ChatPresenterDeps<'_>,
+        state: &ChatPresenterState<'_>,
+        view_tx: &mut mpsc::Sender<ViewCommand>,
+        text: String,
+        conversation_id: Option<Uuid>,
+    ) {
+        Self::handle_send_message(
+            deps.conversation_service,
+            deps.chat_service,
+            deps.profile_service,
+            view_tx,
+            text,
+            conversation_id,
+            state.pending_draft_conversation_id,
+        )
+        .await;
+    }
+
+    async fn handle_new_conversation_for_event(
+        deps: &ChatPresenterDeps<'_>,
+        state: &ChatPresenterState<'_>,
+        view_tx: &mut mpsc::Sender<ViewCommand>,
+    ) {
+        Self::handle_new_conversation(
+            deps.conversation_service,
+            deps.profile_service,
+            view_tx,
+            state.pending_draft_conversation_id,
+        )
+        .await;
+    }
+
+    async fn handle_rename_conversation_for_event(
+        deps: &ChatPresenterDeps<'_>,
+        view_tx: &mut mpsc::Sender<ViewCommand>,
+        id: Uuid,
+        title: String,
+    ) {
+        Self::handle_rename_conversation(deps.conversation_service, view_tx, id, title).await;
+    }
+
+    async fn handle_select_conversation_for_event(
+        deps: &ChatPresenterDeps<'_>,
+        view_tx: &mut mpsc::Sender<ViewCommand>,
+        id: Uuid,
+        selection_generation: u64,
+    ) {
+        Self::handle_select_conversation(
+            deps.conversation_service,
+            view_tx,
+            id,
+            selection_generation,
+        )
+        .await;
+    }
+
+    async fn handle_select_export_format_for_event(
+        state: &ChatPresenterState<'_>,
+        view_tx: &mut mpsc::Sender<ViewCommand>,
+        format: ConversationExportFormat,
+    ) {
+        Self::handle_select_conversation_export_format(
+            state.app_settings_service,
+            state.current_export_format,
+            view_tx,
+            format,
+        )
+        .await;
+    }
+
+    async fn handle_save_conversation_for_event(
+        deps: &ChatPresenterDeps<'_>,
+        state: &ChatPresenterState<'_>,
+        view_tx: &mut mpsc::Sender<ViewCommand>,
+    ) {
+        Self::handle_save_conversation(
+            deps.conversation_service,
+            state.app_settings_service,
+            state.current_export_format,
+            view_tx,
+        )
+        .await;
+    }
+
+    async fn handle_tool_approval_response_for_event(
+        deps: &ChatPresenterDeps<'_>,
+        view_tx: &mpsc::Sender<ViewCommand>,
+        request_id: String,
+        decision: ToolApprovalResponseAction,
+    ) {
+        Self::handle_tool_approval_response(deps.chat_service, view_tx, request_id, decision).await;
+    }
+}

--- a/src/presentation/chat_presenter_tests.rs
+++ b/src/presentation/chat_presenter_tests.rs
@@ -263,6 +263,7 @@ async fn test_handle_send_message_emits_events() {
             &profile_svc,
             &mut tx,
             content,
+            None,
         )
         .await;
     });

--- a/src/presentation/chat_presenter_tests.rs
+++ b/src/presentation/chat_presenter_tests.rs
@@ -255,6 +255,7 @@ async fn test_handle_send_message_emits_events() {
     let conv_service = conversation_service.clone();
     let chat_svc = chat_service.clone();
     let profile_svc = profile_service.clone();
+    let pending_draft_conversation_id = Arc::new(std::sync::Mutex::new(None));
 
     tokio::spawn(async move {
         ChatPresenter::handle_send_message(
@@ -264,6 +265,7 @@ async fn test_handle_send_message_emits_events() {
             &mut tx,
             content,
             None,
+            &pending_draft_conversation_id,
         )
         .await;
     });
@@ -383,11 +385,13 @@ async fn test_handle_new_conversation() {
     let conversation_service = Arc::new(MockConversationService) as Arc<dyn ConversationService>;
     let profile_service = Arc::new(MockProfileService) as Arc<dyn ProfileService>;
     let (view_tx, mut view_rx) = mpsc::channel::<ViewCommand>(100);
+    let pending_draft_conversation_id = Arc::new(std::sync::Mutex::new(None));
 
     ChatPresenter::handle_new_conversation(
         &conversation_service,
         &profile_service,
         &mut view_tx.clone(),
+        &pending_draft_conversation_id,
     )
     .await;
 

--- a/src/presentation/mod.rs
+++ b/src/presentation/mod.rs
@@ -40,6 +40,8 @@
 pub mod api_key_manager_presenter;
 pub mod chat_presenter;
 mod chat_presenter_emoji;
+mod chat_presenter_event;
+
 mod chat_presenter_export;
 mod chat_presenter_handlers;
 mod conversation_export;

--- a/src/services/profile_impl.rs
+++ b/src/services/profile_impl.rs
@@ -368,9 +368,26 @@ impl ProfileServiceImpl {
             super::ServiceError::Io(format!("Failed to read default profile file: {e}"))
         })?;
 
-        serde_json::from_str(&content).map(Some).map_err(|e| {
-            super::ServiceError::Serialization(format!("Failed to parse default profile ID: {e}"))
-        })
+        match serde_json::from_str::<Uuid>(&content) {
+            Ok(id) => Ok(Some(id)),
+            Err(uuid_error) => Self::parse_legacy_default_profile_id(&content)
+                .map(Some)
+                .map_err(|legacy_error| {
+                    super::ServiceError::Serialization(format!(
+                        "Failed to parse default profile ID: {uuid_error}; legacy shape error: \
+                         {legacy_error}"
+                    ))
+                }),
+        }
+    }
+
+    fn parse_legacy_default_profile_id(content: &str) -> Result<Uuid, serde_json::Error> {
+        #[derive(serde::Deserialize)]
+        struct LegacyDefaultProfile {
+            profile_id: Uuid,
+        }
+
+        serde_json::from_str::<LegacyDefaultProfile>(content).map(|profile| profile.profile_id)
     }
 
     /// Save the default profile ID to disk
@@ -865,6 +882,42 @@ mod tests {
             .unwrap();
 
         service.set_default(profile.id).await.unwrap();
+
+        let default = service.get_default().await.unwrap().unwrap();
+        assert_eq!(default.id, profile.id);
+    }
+
+    #[tokio::test]
+    async fn test_get_default_accepts_legacy_profile_id_object() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let service = ProfileServiceImpl::new(temp_dir.path().to_path_buf()).unwrap();
+        service.initialize().await.unwrap();
+
+        let auth = AuthConfig::Keychain {
+            label: "test-key".to_string(),
+        };
+        let params = ModelParameters::default();
+
+        let profile = service
+            .create(
+                "Profile 1".to_string(),
+                "openai".to_string(),
+                "gpt-4".to_string(),
+                None,
+                auth,
+                params,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let legacy_default = serde_json::json!({ "profile_id": profile.id });
+        std::fs::write(
+            service.default_profile_path(),
+            serde_json::to_string_pretty(&legacy_default).unwrap(),
+        )
+        .unwrap();
 
         let default = service.get_default().await.unwrap().unwrap();
         assert_eq!(default.id, profile.id);

--- a/src/ui_gpui/views/chat_view/mod.rs
+++ b/src/ui_gpui/views/chat_view/mod.rs
@@ -939,7 +939,10 @@ impl ChatView {
         text: String,
         cx: &mut gpui::Context<Self>,
     ) {
-        self.emit(UserEvent::SendMessage { text });
+        self.emit(UserEvent::SendMessage {
+            text,
+            conversation_id: self.conversation_id,
+        });
         self.state.input_text.clear();
         self.state.cursor_position = 0;
         self.state.chat_autoscroll_enabled = true;

--- a/src/ui_gpui/views/chat_view/mod_tests.rs
+++ b/src/ui_gpui/views/chat_view/mod_tests.rs
@@ -872,6 +872,7 @@ async fn plain_enter_still_submits_message(cx: &mut TestAppContext) {
                 user_rx.try_recv().ok(),
                 Some(UserEvent::SendMessage {
                     text: "send me".to_string(),
+                    conversation_id: None,
                 })
             );
             assert!(view.state.input_text.is_empty());
@@ -882,6 +883,33 @@ async fn plain_enter_still_submits_message(cx: &mut TestAppContext) {
                     content: String::new(),
                     done: false,
                 }
+            );
+        });
+    });
+}
+
+#[gpui::test]
+async fn send_message_targets_selected_conversation(cx: &mut TestAppContext) {
+    let view = cx.new(|cx| ChatView::new(ChatState::default(), cx));
+    let mut visual_cx = cx.add_empty_window().clone();
+    let (bridge, user_rx) = make_chat_bridge();
+    let conversation_id = Uuid::new_v4();
+
+    visual_cx.update(|_window, app| {
+        view.update(app, |view: &mut ChatView, cx| {
+            view.set_bridge(bridge.clone());
+            view.conversation_id = Some(conversation_id);
+            view.state.input_text = "continue here".to_string();
+            view.state.cursor_position = view.state.input_text.len();
+
+            view.handle_key_down(&chat_key_event("enter"), cx);
+
+            assert_eq!(
+                user_rx.try_recv().ok(),
+                Some(UserEvent::SendMessage {
+                    text: "continue here".to_string(),
+                    conversation_id: Some(conversation_id),
+                })
             );
         });
     });

--- a/tests/chat_presenter_coverage_tests.rs
+++ b/tests/chat_presenter_coverage_tests.rs
@@ -752,7 +752,8 @@ async fn send_message_reports_chat_service_errors_and_hides_thinking() {
 
     event_bus
         .publish(AppEvent::User(UserEvent::SendMessage {
-            conversation_id: None,
+            conversation_id: Some(conversation_id),
+
             text: "boom".to_string(),
         }))
         .expect("publish send event");
@@ -902,6 +903,77 @@ async fn new_conversation_creates_and_activates_conversation() {
     assert!(commands.iter().any(|command| matches!(
         command,
         ViewCommand::ConversationListRefreshed { conversations } if conversations.iter().any(|c| c.id == created_id)
+    )));
+}
+
+#[tokio::test]
+async fn draft_send_reuses_only_pending_new_conversation() {
+    let default_profile = profile();
+    let profile_id = default_profile.id;
+    let stale_empty = conversation_with_messages(profile_id, vec![]);
+    let stale_empty_id = stale_empty.id;
+    let conversation_service = Arc::new(MockConversationService::new(
+        vec![stale_empty],
+        Some(stale_empty_id),
+    ));
+    let chat_service = Arc::new(MockChatService::new());
+    let profile_service = Arc::new(MockProfileService::new(Some(default_profile)));
+    let event_bus = Arc::new(EventBus::new(64));
+    let (view_tx, mut view_rx) = mpsc::channel(64);
+    let app_settings_service =
+        Arc::new(MockAppSettingsService::new()) as Arc<dyn AppSettingsService>;
+
+    let mut presenter = ChatPresenter::new(
+        event_bus.clone(),
+        conversation_service,
+        chat_service,
+        profile_service,
+        app_settings_service,
+        view_tx,
+    );
+    presenter.start().await.expect("start presenter");
+    let _ = collect_commands(&mut view_rx).await;
+
+    event_bus
+        .publish(AppEvent::User(UserEvent::NewConversation))
+        .expect("publish new conversation event");
+    let new_commands = collect_commands(&mut view_rx).await;
+    let pending_id = new_commands
+        .iter()
+        .find_map(|command| match command {
+            ViewCommand::ConversationCreated { id, .. } => Some(*id),
+            _ => None,
+        })
+        .expect("new conversation created");
+    assert_ne!(pending_id, stale_empty_id);
+
+    event_bus
+        .publish(AppEvent::User(UserEvent::SendMessage {
+            conversation_id: None,
+            text: "draft goes to pending".to_string(),
+        }))
+        .expect("publish draft send event");
+
+    let send_commands = collect_commands(&mut view_rx).await;
+    assert!(!send_commands
+        .iter()
+        .any(|command| matches!(command, ViewCommand::ConversationCreated { .. })));
+    assert!(send_commands.iter().any(|command| matches!(
+        command,
+        ViewCommand::MessageAppended {
+            conversation_id,
+            role: MessageRole::User,
+            content,
+            ..
+        } if *conversation_id == pending_id && content == "draft goes to pending"
+    )));
+    assert!(!send_commands.iter().any(|command| matches!(
+        command,
+        ViewCommand::MessageAppended {
+            conversation_id,
+            content,
+            ..
+        } if *conversation_id == stale_empty_id && content == "draft goes to pending"
     )));
 }
 

--- a/tests/chat_presenter_coverage_tests.rs
+++ b/tests/chat_presenter_coverage_tests.rs
@@ -565,6 +565,7 @@ async fn send_message_creates_conversation_and_appends_user_message() {
 
     event_bus
         .publish(AppEvent::User(UserEvent::SendMessage {
+            conversation_id: None,
             text: "hello world".to_string(),
         }))
         .expect("publish send event");
@@ -604,6 +605,123 @@ async fn send_message_creates_conversation_and_appends_user_message() {
 }
 
 #[tokio::test]
+async fn draft_send_does_not_reuse_previous_active_conversation() {
+    let default_profile = profile();
+    let profile_id = default_profile.id;
+    let previous = conversation_with_messages(
+        profile_id,
+        vec![Message::user("previous prompt".to_string())],
+    );
+    let previous_id = previous.id;
+    let conversation_service = Arc::new(MockConversationService::new(
+        vec![previous],
+        Some(previous_id),
+    ));
+    let chat_service = Arc::new(MockChatService::new());
+    let profile_service = Arc::new(MockProfileService::new(Some(default_profile)));
+    let event_bus = Arc::new(EventBus::new(64));
+    let (view_tx, mut view_rx) = mpsc::channel(64);
+    let app_settings_service =
+        Arc::new(MockAppSettingsService::new()) as Arc<dyn AppSettingsService>;
+
+    let mut presenter = ChatPresenter::new(
+        event_bus.clone(),
+        conversation_service,
+        chat_service,
+        profile_service,
+        app_settings_service,
+        view_tx,
+    );
+    presenter.start().await.expect("start presenter");
+    let _ = collect_commands(&mut view_rx).await;
+
+    event_bus
+        .publish(AppEvent::User(UserEvent::SendMessage {
+            conversation_id: None,
+            text: "fresh draft prompt".to_string(),
+        }))
+        .expect("publish draft send event");
+
+    let commands = collect_commands(&mut view_rx).await;
+    let new_conversation_id = commands.iter().find_map(|command| match command {
+        ViewCommand::ConversationCreated { id, .. } => Some(*id),
+        _ => None,
+    });
+    let new_conversation_id = new_conversation_id.expect("draft send creates conversation");
+    assert_ne!(new_conversation_id, previous_id);
+    assert!(commands.iter().any(|command| matches!(
+        command,
+        ViewCommand::MessageAppended {
+            conversation_id,
+            role: MessageRole::User,
+            content,
+            ..
+        } if *conversation_id == new_conversation_id && content == "fresh draft prompt"
+    )));
+    assert!(!commands.iter().any(|command| matches!(
+        command,
+        ViewCommand::MessageAppended {
+            conversation_id,
+            content,
+            ..
+        } if *conversation_id == previous_id && content == "fresh draft prompt"
+    )));
+}
+
+#[tokio::test]
+async fn send_message_uses_explicit_selected_conversation() {
+    let default_profile = profile();
+    let profile_id = default_profile.id;
+    let previous = conversation_with_messages(
+        profile_id,
+        vec![Message::user("previous prompt".to_string())],
+    );
+    let previous_id = previous.id;
+    let conversation_service = Arc::new(MockConversationService::new(
+        vec![previous],
+        Some(previous_id),
+    ));
+    let chat_service = Arc::new(MockChatService::new());
+    let profile_service = Arc::new(MockProfileService::new(Some(default_profile)));
+    let event_bus = Arc::new(EventBus::new(64));
+    let (view_tx, mut view_rx) = mpsc::channel(64);
+    let app_settings_service =
+        Arc::new(MockAppSettingsService::new()) as Arc<dyn AppSettingsService>;
+
+    let mut presenter = ChatPresenter::new(
+        event_bus.clone(),
+        conversation_service,
+        chat_service,
+        profile_service,
+        app_settings_service,
+        view_tx,
+    );
+    presenter.start().await.expect("start presenter");
+    let _ = collect_commands(&mut view_rx).await;
+
+    event_bus
+        .publish(AppEvent::User(UserEvent::SendMessage {
+            conversation_id: Some(previous_id),
+            text: "continue selected conversation".to_string(),
+        }))
+        .expect("publish selected send event");
+
+    let commands = collect_commands(&mut view_rx).await;
+    assert!(!commands
+        .iter()
+        .any(|command| matches!(command, ViewCommand::ConversationCreated { .. })));
+    assert!(commands.iter().any(|command| matches!(
+        command,
+        ViewCommand::MessageAppended {
+            conversation_id,
+            role: MessageRole::User,
+            content,
+            ..
+        } if *conversation_id == previous_id && content == "continue selected conversation"
+    )));
+}
+
+#[tokio::test]
 async fn send_message_reports_chat_service_errors_and_hides_thinking() {
     let default_profile = profile();
     let profile_id = default_profile.id;
@@ -634,6 +752,7 @@ async fn send_message_reports_chat_service_errors_and_hides_thinking() {
 
     event_bus
         .publish(AppEvent::User(UserEvent::SendMessage {
+            conversation_id: None,
             text: "boom".to_string(),
         }))
         .expect("publish send event");
@@ -680,6 +799,7 @@ async fn send_message_reports_profile_resolution_errors() {
 
     event_bus
         .publish(AppEvent::User(UserEvent::SendMessage {
+            conversation_id: None,
             text: "hello".to_string(),
         }))
         .expect("publish send event");

--- a/tests/chat_view_handle_command_tests.rs
+++ b/tests/chat_view_handle_command_tests.rs
@@ -271,6 +271,7 @@ async fn handle_enter_emits_send_message_and_ignores_enter_during_streaming(
         user_rx.recv().expect("send message event"),
         UserEvent::SendMessage {
             text: "hello".to_string(),
+            conversation_id: None,
         }
     );
     assert!(

--- a/tests/e2e_presenter_chat.rs
+++ b/tests/e2e_presenter_chat.rs
@@ -405,6 +405,7 @@ async fn test_chat_presenter_error_handling() {
     let _conversation_id = Uuid::new_v4();
     event_bus
         .publish(AppEvent::User(UserEvent::SendMessage {
+            conversation_id: None,
             text: "This should fail".to_string(),
         }))
         .ok();

--- a/tests/gpui_bridge_tests.rs
+++ b/tests/gpui_bridge_tests.rs
@@ -69,6 +69,7 @@ fn test_gpui_bridge_emit_user_event() {
     // Emit a UserEvent
     let result = bridge.emit(UserEvent::SendMessage {
         text: "Hello".to_string(),
+        conversation_id: None,
     });
     assert!(result, "emit should return true on success");
 
@@ -77,7 +78,13 @@ fn test_gpui_bridge_emit_user_event() {
     assert!(received.is_ok(), "Should receive the event");
 
     match received.unwrap() {
-        UserEvent::SendMessage { text } => assert_eq!(text, "Hello"),
+        UserEvent::SendMessage {
+            text,
+            conversation_id,
+        } => {
+            assert_eq!(text, "Hello");
+            assert_eq!(conversation_id, None);
+        }
         _ => panic!("Wrong event type"),
     }
 }
@@ -331,6 +338,7 @@ async fn test_full_bridge_round_trip() {
     // === Simulate GPUI -> tokio ===
     bridge.emit(UserEvent::SendMessage {
         text: "Test".to_string(),
+        conversation_id: None,
     });
 
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
@@ -381,6 +389,7 @@ async fn test_e2e_with_state_application() {
     // 1. GPUI emits UserEvent
     bridge.emit(UserEvent::SendMessage {
         text: "Hello".to_string(),
+        conversation_id: None,
     });
 
     // 2. Verify EventBus received it
@@ -389,7 +398,7 @@ async fn test_e2e_with_state_application() {
     assert!(received.is_ok());
     assert!(matches!(
         received.unwrap(),
-        AppEvent::User(UserEvent::SendMessage { text }) if text == "Hello"
+        AppEvent::User(UserEvent::SendMessage { text, conversation_id }) if text == "Hello" && conversation_id.is_none()
     ));
 
     // 3. Simulate presenter sending ViewCommand


### PR DESCRIPTION
## Summary

- carry the UI-selected conversation id with SendMessage events
- treat a None send target as an intentional new-chat draft so stale service-active conversations are not reused
- add presenter and ChatView regression coverage for draft sends and explicit selected-conversation sends

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --tests
- cargo xtask guard
- python3 -m lizard -C 50 -L 100 -w src/

Fixes #203


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sent messages now include the selected conversation context so messages go to the intended conversation.
  * Sending with no selected conversation creates a new draft conversation; empty draft drafts are reused appropriately.

* **Bug Fixes**
  * Default profile loading improved to accept legacy on-disk formats.

* **Tests**
  * Coverage updated to validate conversation selection, draft-reuse behaviors, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->