### PR TITLE
Show focused text input cursors (Fixes #206)

### DIFF
--- a/src/ui_gpui/views/chat_view/focus.rs
+++ b/src/ui_gpui/views/chat_view/focus.rs
@@ -1,0 +1,60 @@
+use super::ChatView;
+
+impl ChatView {
+    #[cfg(test)]
+    pub(super) fn composer_display_text_for_test(&self, cx: &gpui::App) -> String {
+        self.composer_display_text(cx)
+    }
+
+    pub(super) fn composer_display_text(&self, cx: &gpui::App) -> String {
+        Self::format_composer_display_text(
+            &self.state.input_text,
+            self.state.cursor_position,
+            self.composer_has_focus(cx),
+        )
+    }
+
+    fn format_composer_display_text(
+        input_text: &str,
+        cursor_position: usize,
+        composer_focused: bool,
+    ) -> String {
+        if input_text.is_empty() {
+            if composer_focused {
+                "|".to_string()
+            } else {
+                "Type a message...".to_string()
+            }
+        } else if composer_focused {
+            let cursor_pos = cursor_position.min(input_text.len());
+            let before = &input_text[..cursor_pos];
+            let after = &input_text[cursor_pos..];
+            format!("{before}|{after}")
+        } else {
+            input_text.to_string()
+        }
+    }
+
+    pub(super) fn composer_has_focus(&self, cx: &gpui::App) -> bool {
+        self.state.composer_focused
+            && !self.sidebar_search_focused(cx)
+            && !self.state.conversation_title_editing
+            && !self.state.conversation_dropdown_open
+            && !self.state.profile_dropdown_open
+    }
+
+    pub(super) fn focus_composer(&mut self, cx: &mut gpui::Context<Self>) {
+        self.state.composer_focused = true;
+        self.state.conversation_title_editing = false;
+        self.state.conversation_dropdown_open = false;
+        self.state.profile_dropdown_open = false;
+        if self.sidebar_search_focused(cx) {
+            self.set_sidebar_search_focused(false, cx);
+        }
+        cx.notify();
+    }
+
+    pub(super) const fn blur_composer(&mut self) {
+        self.state.composer_focused = false;
+    }
+}

--- a/src/ui_gpui/views/chat_view/mod.rs
+++ b/src/ui_gpui/views/chat_view/mod.rs
@@ -11,9 +11,14 @@
 //! @requirement REQ-GPUI-003
 
 mod command;
+mod focus;
+
 mod ime;
 mod render;
 mod render_bars;
+#[cfg(test)]
+mod render_bars_tests;
+
 mod render_bars_export;
 
 mod render_sidebar;

--- a/src/ui_gpui/views/chat_view/mod_tests.rs
+++ b/src/ui_gpui/views/chat_view/mod_tests.rs
@@ -701,6 +701,28 @@ async fn apply_store_snapshot_thinking_only_skips_maybe_scroll_when_autoscroll_d
 }
 
 #[gpui::test]
+async fn empty_composer_shows_cursor_only_when_focused(cx: &mut TestAppContext) {
+    let view = cx.new(|cx| ChatView::new(ChatState::default(), cx));
+    let mut visual_cx = cx.add_empty_window().clone();
+
+    visual_cx.update(|_window, app| {
+        view.update(app, |view: &mut ChatView, cx| {
+            assert_eq!(view.composer_display_text_for_test(cx), "Type a message...");
+
+            view.focus_composer(cx);
+            assert_eq!(view.composer_display_text_for_test(cx), "|");
+
+            view.state.input_text = "hello".to_string();
+            view.state.cursor_position = 2;
+            assert_eq!(view.composer_display_text_for_test(cx), "he|llo");
+
+            view.blur_composer();
+            assert_eq!(view.composer_display_text_for_test(cx), "hello");
+        });
+    });
+}
+
+#[gpui::test]
 async fn send_message_and_start_streaming_reenables_autoscroll_and_starts_stream(
     cx: &mut TestAppContext,
 ) {

--- a/src/ui_gpui/views/chat_view/render.rs
+++ b/src/ui_gpui/views/chat_view/render.rs
@@ -638,7 +638,6 @@ impl ChatView {
         let input_text = self.state.input_text.clone();
         let has_text = !input_text.trim().is_empty();
         let focus_handle = self.focus_handle.clone();
-        let cursor_pos = self.state.cursor_position.min(input_text.len());
 
         let wrapped_line_count = if input_text.is_empty() {
             1
@@ -664,13 +663,8 @@ impl ChatView {
         #[allow(clippy::cast_precision_loss)]
         let computed_height = (wrapped_line_count as f32).mul_add(line_height, 14.0);
         let input_box_height = computed_height.clamp(min_composer_height, max_composer_height);
-        let text_content = if input_text.is_empty() {
-            "Type a message...".to_string()
-        } else {
-            let before = &input_text[..cursor_pos];
-            let after = &input_text[cursor_pos..];
-            format!("{before}|{after}")
-        };
+        let focused = self.composer_has_focus(cx);
+        let text_content = self.composer_display_text(cx);
 
         div()
             .id("input-bar-container")
@@ -702,10 +696,13 @@ impl ChatView {
                 line_height,
                 &input_text,
                 text_content,
+                focused,
+                cx,
             ))
             .child(self.render_send_stop_button(is_streaming, has_text, cx))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_composer_field(
         focus_handle: gpui::FocusHandle,
         input_box_height: f32,
@@ -713,6 +710,8 @@ impl ChatView {
         line_height: f32,
         input_text: &str,
         text_content: String,
+        focused: bool,
+        cx: &mut gpui::Context<Self>,
     ) -> impl IntoElement {
         div()
             .id("input-field")
@@ -724,21 +723,29 @@ impl ChatView {
             .px(px(Theme::SPACING_SM))
             .py(px(7.0))
             .bg(Theme::bg_darkest())
+            .border_1()
+            .border_color(if focused {
+                Theme::accent()
+            } else {
+                Theme::border()
+            })
             .rounded(px(Theme::RADIUS_MD))
             .overflow_x_hidden()
             .overflow_y_scroll()
             .cursor_text()
-            .on_mouse_down(MouseButton::Left, {
-                move |_, window, cx| {
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, window, cx| {
                     window.focus(&focus_handle, cx);
-                }
-            })
+                    this.focus_composer(cx);
+                }),
+            )
             .child(
                 div()
                     .w_full()
                     .text_size(px(Theme::font_size_mono()))
                     .line_height(px(line_height))
-                    .text_color(if input_text.is_empty() {
+                    .text_color(if input_text.is_empty() && !focused {
                         Theme::text_secondary()
                     } else {
                         Theme::text_primary()

--- a/src/ui_gpui/views/chat_view/render_bars.rs
+++ b/src/ui_gpui/views/chat_view/render_bars.rs
@@ -236,6 +236,8 @@ impl ChatView {
                 "R",
                 false,
                 cx.listener(|this, _, _window, cx| {
+                    this.blur_composer();
+
                     this.start_rename_conversation(cx);
                 })
             ))
@@ -613,6 +615,7 @@ impl ChatView {
                     MouseButton::Left,
                     cx.listener(|this, _, _window, cx| {
                         this.toggle_conversation_dropdown(cx);
+                        this.blur_composer();
                     }),
                 )
         }
@@ -709,6 +712,8 @@ impl ChatView {
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|this, _, _window, cx| {
+                    this.blur_composer();
+
                     this.toggle_profile_dropdown(cx);
                 }),
             )
@@ -966,35 +971,5 @@ impl ChatView {
         } else {
             0.0
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use gpui::px;
-
-    #[test]
-    fn profile_dropdown_left_aligns_under_trigger_in_popup() {
-        let left = ChatView::compute_profile_dropdown_left(px(760.0), 0.0);
-        assert_eq!(left, px(276.0));
-    }
-
-    #[test]
-    fn profile_dropdown_left_shifts_for_sidebar_toggle_in_popout() {
-        let left = ChatView::compute_profile_dropdown_left(px(760.0), 36.0);
-        assert_eq!(left, px(312.0));
-    }
-
-    #[test]
-    fn profile_dropdown_left_clamps_to_right_bound_on_narrow_windows() {
-        let clamped_right = ChatView::compute_profile_dropdown_left(px(520.0), 0.0);
-        assert_eq!(clamped_right, px(248.0));
-    }
-
-    #[test]
-    fn profile_dropdown_left_uses_minimum_margin_for_narrow_windows() {
-        let left = ChatView::compute_profile_dropdown_left(px(200.0), 0.0);
-        assert_eq!(left, px(12.0));
     }
 }

--- a/src/ui_gpui/views/chat_view/render_bars_tests.rs
+++ b/src/ui_gpui/views/chat_view/render_bars_tests.rs
@@ -1,0 +1,29 @@
+#[cfg(test)]
+mod tests {
+    use super::super::ChatView;
+    use gpui::px;
+
+    #[test]
+    fn profile_dropdown_left_aligns_under_trigger_in_popup() {
+        let left = ChatView::compute_profile_dropdown_left(px(760.0), 0.0);
+        assert_eq!(left, px(276.0));
+    }
+
+    #[test]
+    fn profile_dropdown_left_shifts_for_sidebar_toggle_in_popout() {
+        let left = ChatView::compute_profile_dropdown_left(px(760.0), 36.0);
+        assert_eq!(left, px(312.0));
+    }
+
+    #[test]
+    fn profile_dropdown_left_clamps_to_right_bound_on_narrow_windows() {
+        let clamped_right = ChatView::compute_profile_dropdown_left(px(520.0), 0.0);
+        assert_eq!(clamped_right, px(248.0));
+    }
+
+    #[test]
+    fn profile_dropdown_left_uses_minimum_margin_for_narrow_windows() {
+        let left = ChatView::compute_profile_dropdown_left(px(200.0), 0.0);
+        assert_eq!(left, px(12.0));
+    }
+}

--- a/src/ui_gpui/views/chat_view/state.rs
+++ b/src/ui_gpui/views/chat_view/state.rs
@@ -221,6 +221,8 @@ pub struct ChatState {
     pub thinking_content: Option<String>,
     pub input_text: String,
     pub cursor_position: usize,
+    pub composer_focused: bool,
+
     pub conversation_title: String,
     pub current_model: String,
     pub profiles: Vec<ProfileSummary>,
@@ -275,6 +277,8 @@ impl Default for ChatState {
             streaming: StreamingState::Idle,
             show_thinking: false,
             thinking_content: None,
+            composer_focused: false,
+
             input_text: String::new(),
             cursor_position: 0,
             conversation_title: "New Conversation".to_string(),

--- a/src/ui_gpui/views/conversation_list/render.rs
+++ b/src/ui_gpui/views/conversation_list/render.rs
@@ -71,15 +71,7 @@ impl ConversationListView {
                     } else {
                         Theme::text_primary()
                     })
-                    .child(if query.is_empty() && !is_focused {
-                        SharedString::from("Search conversations...")
-                    } else if query.is_empty() {
-                        SharedString::from("|")
-                    } else if is_focused {
-                        SharedString::from(format!("{query}|"))
-                    } else {
-                        SharedString::from(query)
-                    })
+                    .child(Self::search_field_display_text(&query, is_focused))
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(|this, _, window, cx| {
@@ -129,6 +121,18 @@ impl ConversationListView {
             || SharedString::from("CONVERSATIONS"),
             |results| SharedString::from(format!("{} results", results.len())),
         )
+    }
+
+    fn search_field_display_text(query: &str, is_focused: bool) -> SharedString {
+        if query.is_empty() && !is_focused {
+            SharedString::from("Search conversations...")
+        } else if query.is_empty() {
+            SharedString::from("|")
+        } else if is_focused {
+            SharedString::from(format!("{query}|"))
+        } else {
+            SharedString::from(query.to_string())
+        }
     }
 
     fn render_list(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {

--- a/src/ui_gpui/views/model_selector_view/command.rs
+++ b/src/ui_gpui/views/model_selector_view/command.rs
@@ -48,6 +48,7 @@ impl ModelSelectorView {
 
     pub(super) fn toggle_provider_dropdown(&mut self, cx: &mut gpui::Context<Self>) {
         self.state.show_provider_dropdown = !self.state.show_provider_dropdown;
+        self.state.search_focused = false;
         cx.notify();
     }
 
@@ -84,6 +85,7 @@ impl ModelSelectorView {
             model_id,
         });
         self.state.show_provider_dropdown = false;
+        self.state.search_focused = false;
     }
 
     pub(super) fn handle_key_down(
@@ -95,6 +97,7 @@ impl ModelSelectorView {
         let modifiers = &event.keystroke.modifiers;
 
         if key == "escape" {
+            self.state.search_focused = false;
             if self.state.show_provider_dropdown {
                 self.state.show_provider_dropdown = false;
                 cx.notify();
@@ -112,6 +115,7 @@ impl ModelSelectorView {
         }
 
         if !modifiers.platform && !modifiers.control && key == "backspace" {
+            self.state.search_focused = true;
             self.state.search_query.pop();
             self.rebuild_and_reset_scroll(cx);
         }

--- a/src/ui_gpui/views/model_selector_view/ime.rs
+++ b/src/ui_gpui/views/model_selector_view/ime.rs
@@ -69,6 +69,7 @@ impl gpui::EntityInputHandler for ModelSelectorView {
             self.ime_marked_byte_count = 0;
         }
         if !text.is_empty() {
+            self.state.search_focused = true;
             self.state.search_query.push_str(text);
         }
         self.rebuild_and_reset_scroll(cx);
@@ -90,6 +91,7 @@ impl gpui::EntityInputHandler for ModelSelectorView {
             self.ime_marked_byte_count = 0;
         }
         if !new_text.is_empty() {
+            self.state.search_focused = true;
             self.state.search_query.push_str(new_text);
             self.ime_marked_byte_count = new_text.len();
         }

--- a/src/ui_gpui/views/model_selector_view/mod.rs
+++ b/src/ui_gpui/views/model_selector_view/mod.rs
@@ -131,6 +131,7 @@ pub(super) struct SearchableModelInfo {
 
 /// Model Selector view state
 /// @plan PLAN-20250130-GPUIREDUX.P07
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Default)]
 pub struct ModelSelectorState {
     // NOTE: unused for rendering — see cached_providers
@@ -141,6 +142,8 @@ pub struct ModelSelectorState {
     pub filter_reasoning: bool,
     pub filter_vision: bool,
     pub show_provider_dropdown: bool,
+    pub search_focused: bool,
+
     pub(super) searchable_models: Vec<SearchableModelInfo>,
     pub(super) cached_providers: Vec<String>,
     pub(super) cached_display_rows: Vec<DisplayRow>,

--- a/src/ui_gpui/views/model_selector_view/render.rs
+++ b/src/ui_gpui/views/model_selector_view/render.rs
@@ -65,10 +65,64 @@ impl ModelSelectorView {
             .child(div().w(px(70.0)))
     }
 
+    fn render_search_field(
+        search_query: String,
+        search_focused: bool,
+        cx: &mut gpui::Context<Self>,
+    ) -> impl IntoElement {
+        div()
+            .id("search-field")
+            .flex_1()
+            .h(px(28.0))
+            .px(px(8.0))
+            .bg(Theme::bg_dark())
+            .border_1()
+            .border_color(if search_focused {
+                Theme::accent()
+            } else {
+                Theme::border()
+            })
+            .rounded(px(4.0))
+            .flex()
+            .items_center()
+            .cursor_text()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    this.state.search_focused = true;
+                    this.state.show_provider_dropdown = false;
+                    window.focus(&this.focus_handle, cx);
+                    cx.notify();
+                }),
+            )
+            .child(if search_query.is_empty() && !search_focused {
+                div()
+                    .text_size(px(Theme::font_size_mono()))
+                    .text_color(Theme::text_muted())
+                    .child("Search models...")
+            } else if search_query.is_empty() {
+                div()
+                    .text_size(px(Theme::font_size_mono()))
+                    .text_color(Theme::text_primary())
+                    .child("|")
+            } else if search_focused {
+                div()
+                    .text_size(px(Theme::font_size_mono()))
+                    .text_color(Theme::text_primary())
+                    .child(format!("{search_query}|"))
+            } else {
+                div()
+                    .text_size(px(Theme::font_size_mono()))
+                    .text_color(Theme::text_primary())
+                    .child(search_query)
+            })
+    }
+
     /// Render the filter bar with search and provider dropdown
     /// @plan PLAN-20250130-GPUIREDUX.P07
     fn render_filter_bar(&self, cx: &mut gpui::Context<Self>) -> impl IntoElement {
         let search_query = self.state.search_query.clone();
+        let search_focused = self.state.search_focused;
         let provider_display = self
             .state
             .selected_provider
@@ -85,32 +139,7 @@ impl ModelSelectorView {
             .flex()
             .items_center()
             .gap(px(8.0))
-            // Search field
-            .child(
-                div()
-                    .id("search-field")
-                    .flex_1()
-                    .h(px(28.0))
-                    .px(px(8.0))
-                    .bg(Theme::bg_dark())
-                    .border_1()
-                    .border_color(Theme::border())
-                    .rounded(px(4.0))
-                    .flex()
-                    .items_center()
-                    .cursor_text()
-                    .child(if search_query.is_empty() {
-                        div()
-                            .text_size(px(Theme::font_size_mono()))
-                            .text_color(Theme::text_muted())
-                            .child("Search models...")
-                    } else {
-                        div()
-                            .text_size(px(Theme::font_size_mono()))
-                            .text_color(Theme::text_primary())
-                            .child(search_query)
-                    }),
-            )
+            .child(Self::render_search_field(search_query, search_focused, cx))
             // Provider dropdown button
             .child(
                 div()


### PR DESCRIPTION
## Summary
- add explicit chat composer focus state so the empty composer shows a cursor when focused
- add accent focus styling and visible cursor text to the chat composer and model selector search field
- keep sidebar search cursor display logic isolated and covered by the existing state-driven focus path

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --tests -- --test-threads=1
- python3 -m lizard -C 50 -L 100 -w src/

Fixes #206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved composer focus handling with better cursor visibility when active
  * Enhanced search field display states across conversation list and model selector views
  * Added focus state tracking for the message composer

* **Bug Fixes**
  * Conversation dropdown now properly clears composer focus when opened
  * Search field focus management improved during IME text input

* **Tests**
  * Added test coverage for composer cursor display behavior in focused and unfocused states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->